### PR TITLE
Carry the DatumDomain type in the StubType as type member `type`

### DIFF
--- a/documentation/pages/user/api.rst
+++ b/documentation/pages/user/api.rst
@@ -134,6 +134,7 @@ Datum domain
 
 .. doxygentypedef:: llama::StubType
    :project: LLAMA
+   :members:
 
 .. doxygentypedef:: llama::GetDatumElementType
    :project: LLAMA

--- a/examples/simpletest/simpletest.cpp
+++ b/examples/simpletest/simpletest.cpp
@@ -13,6 +13,7 @@
 
 #include <iostream>
 #include <utility>
+#include <vector>
 #include <llama/llama.hpp>
 
 #include "../common/demangle.hpp"
@@ -129,10 +130,17 @@ int main(int argc,char * * argv)
         << "SizeOf DatumDomain: "
         << llama::SizeOf< Name >::value
         << std::endl;
+    using NameStub = llama::StubType< Name >;
+    static_assert( std::is_same<Name, NameStub::type >::value,
+                   "Type from StubType does not match original type" );
     std::cout
         << "sizeof( llama::StubType< DatumDomain > ): "
-        << sizeof( llama::StubType< Name > )
+        << sizeof( NameStub )
         << std::endl;
+
+    std::vector<NameStub> v;
+    static_assert( std::is_same<Name, decltype(v)::value_type::type >::value,
+                   "Type from StubType does not match original type" );
 
     std::cout << type( llama::GetCoordFromUID< Name, st::Pos, st::X >() ) << '\n';
 

--- a/include/llama/DatumStruct.hpp
+++ b/include/llama/DatumStruct.hpp
@@ -160,6 +160,7 @@ struct StubTypeImpl
 {
     using type = struct
     {
+        using type = T_DatumDomain;
         unsigned char stub[ SizeOf< T_DatumDomain >::value ];
     };
 };
@@ -170,6 +171,8 @@ struct StubTypeImpl
  *  datum domain, useful e.g. if an external memory allocation function needs a
  *  type and a number of elements instead of the total size in bytes.
  * \tparam T_DatumDomain the datum domain type to create a stub type for
+ *  Additionally, this type has a type member named \a type which holds the
+ *  original datum domain type.
  */
 template< typename T_DatumDomain >
 using StubType = typename internal::StubTypeImpl< T_DatumDomain >::type;


### PR DESCRIPTION
This allows to pass the StubType to the external container, but also work
later on that type again with LLAMA by only having a container object.