### PR TITLE
datum tag objects to access members

### DIFF
--- a/examples/simpletest/simpletest.cpp
+++ b/examples/simpletest/simpletest.cpp
@@ -165,12 +165,17 @@ int main(int argc,char * * argv)
     // defining a position in the user domain
     const UD pos{ 0, 0 };
 
+    st::Options Options_;
+    const auto Weight_ = st::Weight{};
+
     // using the position in the user domain and a tree coord or a uid in the
     // datum domain to get the reference to an element in the view
     float& position_x = view( pos ).access< 0, 0 >();
     double& momentum_z = view[ pos ].access< st::Momentum, st::Z >();
     int& weight = view[ {0,0} ]( llama::DatumCoord< 2 >() );
+    int& weight_2 = view( pos )( Weight_ );
     bool& options_2 = view[ 0 ]( st::Options() )( llama::DatumCoord< 2 >() );
+    bool& options_3 = view( pos )( Options_ )( llama::DatumCoord< 2 >() );
     // printing the address and distances of the element in the memory. This
     // will change based on the chosen mapping. When array of struct is chosen
     // instead the elements will be much closer than with struct of array.

--- a/include/llama/TypeTraits.hpp
+++ b/include/llama/TypeTraits.hpp
@@ -1,0 +1,45 @@
+/* Copyright 2019 Rene Widera
+ *
+ * This file is part of LLAMA.
+ *
+ * LLAMA is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * LLAMA is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+namespace llama
+{
+
+    /** remove const end reference
+     *
+     * This trait is equal to the C++20 remove_cvref.
+     *
+     * \attention This trait will not collide with the C++20 trait since it
+     *            is defined in the llama namespace.
+     */
+    template< typename T >
+    struct remove_cvref
+    {
+        using type = typename std::remove_cv<
+            typename std::remove_reference< T >::type
+        >::type;
+    };
+
+    //! short hand for remove_cvref
+    template< typename T >
+    using remove_cvref_t = typename remove_cvref< T >::type;
+
+} // namespace llama

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018 Alexander Matthes
+/* Copyright 2018 Alexander Matthes, Rene Widera
  *
  * This file is part of LLAMA.
  *
@@ -18,15 +18,16 @@
 
 #pragma once
 
-#include <boost/preprocessor/cat.hpp>
-#include <type_traits>
-
 #include "preprocessor/macros.hpp"
 #include "GetType.hpp"
 #include "Array.hpp"
 #include "ForEach.hpp"
 #include "CompareUID.hpp"
 #include "Factory.hpp"
+#include "TypeTraits.hpp"
+
+#include <boost/preprocessor/cat.hpp>
+#include <type_traits>
 
 namespace llama
 {
@@ -1000,14 +1001,14 @@ struct VirtualDatum : T_ViewType< T_View >
     template< typename... T_DatumCoordOrUIDs  >
     LLAMA_FN_HOST_ACC_INLINE
     auto
-    access( T_DatumCoordOrUIDs&&... )
-    -> decltype( AccessWithTypeImpl< T_DatumCoordOrUIDs... >::apply(
+    access( T_DatumCoordOrUIDs && ... )
+    -> decltype( AccessWithTypeImpl< remove_cvref_t< T_DatumCoordOrUIDs>... >::apply(
             std::forward<T_View>(this->view),
             userDomainPos
         ) ) // & should be in decltype if …::apply returns a reference
     {
         LLAMA_FORCE_INLINE_RECURSIVE
-        return AccessWithTypeImpl< T_DatumCoordOrUIDs... >::apply(
+        return AccessWithTypeImpl< remove_cvref_t< T_DatumCoordOrUIDs>... >::apply(
             std::forward<T_View>(this->view),
             userDomainPos
         );
@@ -1077,19 +1078,19 @@ struct VirtualDatum : T_ViewType< T_View >
     template< typename... T_DatumCoordOrUIDs  >
     LLAMA_FN_HOST_ACC_INLINE
     auto
-    operator()( T_DatumCoordOrUIDs&&... LLAMA_IGNORE_LITERAL( datumCoordOrUIDs ) )
+    operator()( T_DatumCoordOrUIDs && ... LLAMA_IGNORE_LITERAL( datumCoordOrUIDs ) )
 #if !BOOST_COMP_INTEL && !BOOST_COMP_NVCC
-    -> decltype( access< T_DatumCoordOrUIDs... >() )
+    -> decltype( access< remove_cvref_t< T_DatumCoordOrUIDs >... >() )
     // & should be in decltype if …::apply returns a reference
 #else //Intel compiler bug work around
-    -> decltype( AccessWithTypeImpl< T_DatumCoordOrUIDs... >::apply(
+    -> decltype( AccessWithTypeImpl< remove_cvref_t< T_DatumCoordOrUIDs >... >::apply(
         std::forward<T_View>(this->view),
         userDomainPos
     ) ) // & should be in decltype if …::apply returns a reference
 #endif
     {
         LLAMA_FORCE_INLINE_RECURSIVE
-        return access< T_DatumCoordOrUIDs... >();
+        return access< remove_cvref_t< T_DatumCoordOrUIDs >... >();
     }
 
     __LLAMA_VIRTUALDATUM_OPERATOR( =  , Assigment )


### PR DESCRIPTION
This PR implements the same behavior than #21 but without removing the usage of universal references.

Allow using an instance of a datum domain to access members.

Co-authored-by: Bert Wesarg <bert.wesarg@tu-dresden.de>

@bertwesarg could you please have a look to this PR.