### PR TITLE
UpdateKernel: add synchronization

### DIFF
--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -275,7 +275,10 @@ struct UpdateKernel
                 pos2 + threadIndex < end2;
                 pos2 += threads
             )
+            {
                 temp( pos2 + threadBlockIndex ) = particles( start2 + pos2 + threadBlockIndex );
+            }
+            syncBlockThreads( acc );
 #endif // NBODY_USE_SHARED
             LLAMA_INDEPENDENT_DATA
             for ( auto pos2 = decltype( end2 )( 0 ); pos2 < end2; ++pos2 )
@@ -290,7 +293,10 @@ struct UpdateKernel
 #endif // NBODY_USE_SHARED
                         ts
                     );
-        };
+#if NBODY_USE_SHARED == 1
+            syncBlockThreads( acc );
+#endif // NBODY_USE_SHARED
+        }
     }
 };
 


### PR DESCRIPTION
Synchronization to ensure that correct data will be shared independent of blockSize (e.g. when blockSize > Warp size (32) on CUDA devices since only threads within Warp run simultaneously)