### PR TITLE
Switching to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project (llama)
 find_package(Boost 1.66.0 REQUIRED)
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_17)
 target_link_libraries(${PROJECT_NAME} INTERFACE Boost::headers)
 
 # llama::llama to make subdirectory projects work


### PR DESCRIPTION
So I had a call a while back with Michael on how I am allowed to proceed on LLAMA. I specifically asked for use of C++17 and he gave me greenlight. So here is the switch to C++17 in CMake.

I am creating this PR explicitely, because it may make sense to create a tag or release before the switch, just in case anyone wants to use LLAMA without C++17 support.