### PR TITLE
Refactor Alpaka vectoradd example

### DIFF
--- a/examples/alpaka/vectoradd/CMakeLists.txt
+++ b/examples/alpaka/vectoradd/CMakeLists.txt
@@ -6,6 +6,7 @@ if (NOT TARGET llama::llama)
 endif()
 find_package(alpaka 0.5.0 REQUIRED)
 ALPAKA_ADD_EXECUTABLE(${PROJECT_NAME} vectoradd.cpp ../../common/Dummy.cpp)
+target_compile_definitions(${PROJECT_NAME} PUBLIC LLAMA_FN_HOST_ACC_INLINE=ALPAKA_FN_HOST_ACC)
 target_link_libraries(${PROJECT_NAME} PRIVATE llama::llama alpaka::alpaka)
 
 install(FILES "${PROJECT_BINARY_DIR}/llama-alpaka-vectoradd" DESTINATION "bin")

--- a/examples/alpaka/vectoradd/vectoradd.cpp
+++ b/examples/alpaka/vectoradd/vectoradd.cpp
@@ -10,6 +10,7 @@
 #include "../../common/Chrono.hpp"
 
 #include <alpaka/alpaka.hpp>
+#include <alpaka/example/ExampleDefaultAcc.hpp>
 #include <iostream>
 #include <llama/llama.hpp>
 #include <random>
@@ -65,14 +66,12 @@ int main(int argc, char ** argv)
     // ALPAKA
     using Dim = alpaka::dim::DimInt<1>;
     using Size = std::size_t;
-    using Host = alpaka::acc::AccCpuSerial<Dim, Size>;
 
+    using Acc = alpaka::example::ExampleDefaultAcc<Dim, Size>;
     // using Acc = alpaka::acc::AccGpuCudaRt<Dim, Size>;
-    using Acc = alpaka::acc::AccCpuSerial<Dim, Size>;
-    // using Acc = alpaka::acc::AccCpuOmp2Blocks<Dim, Size>;
-    // using Acc = alpaka::acc::AccCpuOmp2Threads<Dim, Size>;
-    // using Acc = alpaka::acc::AccCpuOmp4<Dim, Size>;
-    using DevHost = alpaka::dev::Dev<Host>;
+    // using Acc = alpaka::acc::AccCpuSerial<Dim, Size>;
+
+    using DevHost = alpaka::dev::DevCpu;
     using DevAcc = alpaka::dev::Dev<Acc>;
     using PltfHost = alpaka::pltf::Pltf<DevHost>;
     using PltfAcc = alpaka::pltf::Pltf<DevAcc>;

--- a/examples/common/AlpakaThreadElemsDistribution.hpp
+++ b/examples/common/AlpakaThreadElemsDistribution.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstddef>
+#include <alpaka/alpaka.hpp>
 
 namespace common
 {

--- a/examples/common/AlpakaThreadElemsDistribution.hpp
+++ b/examples/common/AlpakaThreadElemsDistribution.hpp
@@ -14,10 +14,12 @@
 
 #pragma once
 
-#define THREADELEMDIST_MIN_ELEM 2
+#include <cstddef>
 
 namespace common
 {
+    constexpr auto THREADELEMDIST_MIN_ELEM = 2;
+
     /** Returns a good guess for an optimal number of threads and elements in a
      *  block based on the total number of elements in the block.
      */

--- a/include/llama/Tuple.hpp
+++ b/include/llama/Tuple.hpp
@@ -186,11 +186,14 @@ namespace llama
         template<size_t... Is>
         struct TupleTransformHelper<std::index_sequence<Is...>>
         {
-            template<typename Tuple, typename Functor>
+            template<typename... Elements, typename Functor>
             static LLAMA_FN_HOST_ACC_INLINE auto
-            transform(const Tuple & tuple, const Functor & functor)
+            transform(const Tuple<Elements...> & tuple, const Functor & functor)
             {
-                return llama::Tuple{functor(getTupleElement<Is>(tuple))...};
+                // FIXME(bgruber): nvcc fails to compile
+                // Tuple{functor(getTupleElement<Is>(tuple))...}
+                return Tuple<decltype(functor(std::declval<Elements>()))...>{
+                    functor(getTupleElement<Is>(tuple))...};
             }
         };
     }

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -376,7 +376,8 @@ namespace llama
     struct Assignment
     {
         template<typename A, typename B>
-        decltype(auto) operator()(A & a, const B & b) const
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto)
+        operator()(A & a, const B & b) const
         {
             return a = b;
         }
@@ -385,7 +386,8 @@ namespace llama
     struct Addition
     {
         template<typename A, typename B>
-        decltype(auto) operator()(A & a, const B & b) const
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto)
+        operator()(A & a, const B & b) const
         {
             return a += b;
         }
@@ -394,7 +396,8 @@ namespace llama
     struct Subtraction
     {
         template<typename A, typename B>
-        decltype(auto) operator()(A & a, const B & b) const
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto)
+        operator()(A & a, const B & b) const
         {
             return a -= b;
         }
@@ -403,7 +406,8 @@ namespace llama
     struct Multiplication
     {
         template<typename A, typename B>
-        decltype(auto) operator()(A & a, const B & b) const
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto)
+        operator()(A & a, const B & b) const
         {
             return a *= b;
         }
@@ -412,7 +416,8 @@ namespace llama
     struct Division
     {
         template<typename A, typename B>
-        decltype(auto) operator()(A & a, const B & b) const
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto)
+        operator()(A & a, const B & b) const
         {
             return a /= b;
         }
@@ -421,7 +426,8 @@ namespace llama
     struct Modulo
     {
         template<typename A, typename B>
-        decltype(auto) operator()(A & a, const B & b) const
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto)
+        operator()(A & a, const B & b) const
         {
             return a %= b;
         }

--- a/include/llama/mapping/AoS.hpp
+++ b/include/llama/mapping/AoS.hpp
@@ -26,13 +26,13 @@ namespace llama::mapping
     /** Array of struct mapping which can be used for creating a \ref View with
      * a \ref Factory. For the interface details see \ref Factory. \tparam
      * T_UserDomain type of the user domain \tparam T_DatumDomain type of the
-     * datum domain \tparam T_LinearizeUserDomainAdressFunctor Defines how the
+     * datum domain \tparam LinearizeUserDomainAdressFunctor Defines how the
      * user domain should be linearized, e.g. C like with the last dimension
      * being the "fast" one
      *  (\ref LinearizeUserDomainAdress, default) or Fortran like with the first
      *  dimension being the "fast" one (\ref
      * LinearizeUserDomainAdressLikeFortran). \tparam
-     * T_ExtentUserDomainAdressFunctor Defines how the size of the view shall be
+     * ExtentUserDomainAdressFunctor Defines how the size of the view shall be
      * created. Should fit for `T_LinearizeUserDomainAdressFunctor`. Only right
      * now implemented and default value is \ref ExtentUserDomainAdress. \see
      * SoA
@@ -40,8 +40,8 @@ namespace llama::mapping
     template<
         typename T_UserDomain,
         typename T_DatumDomain,
-        typename T_LinearizeUserDomainAdressFunctor = LinearizeUserDomainAdress,
-        typename T_ExtentUserDomainAdressFunctor = ExtentUserDomainAdress>
+        typename LinearizeUserDomainAdressFunctor = LinearizeUserDomainAdress,
+        typename ExtentUserDomainAdressFunctor = ExtentUserDomainAdress>
     struct AoS
     {
         using UserDomain = T_UserDomain;
@@ -55,21 +55,22 @@ namespace llama::mapping
         LLAMA_FN_HOST_ACC_INLINE auto getBlobSize(std::size_t) const
             -> std::size_t
         {
-            return T_ExtentUserDomainAdressFunctor()(userDomainSize)
-                * SizeOf<DatumDomain>::value;
+            return ExtentUserDomainAdressFunctor{}(
+                userDomainSize)*SizeOf<DatumDomain>::value;
         }
 
         template<std::size_t... DatumDomainCoord>
-        auto getBlobNrAndOffset(UserDomain coord) const
+        LLAMA_FN_HOST_ACC_INLINE auto getBlobNrAndOffset(UserDomain coord) const
             -> NrAndOffset
         {
+            LLAMA_FORCE_INLINE_RECURSIVE
             const auto offset
-                = T_LinearizeUserDomainAdressFunctor()(coord, userDomainSize)
+                = LinearizeUserDomainAdressFunctor{}(coord, userDomainSize)
                     * SizeOf<DatumDomain>::value
                 + LinearBytePos<DatumDomain, DatumDomainCoord...>::value;
             return {0, offset};
         }
 
-        UserDomain const userDomainSize;
+        const UserDomain userDomainSize;
     };
 }

--- a/include/llama/mapping/One.hpp
+++ b/include/llama/mapping/One.hpp
@@ -47,7 +47,8 @@ namespace llama::mapping
         }
 
         template<std::size_t... DatumDomainCoord>
-        auto getBlobNrAndOffset(UserDomain coord) const -> NrAndOffset
+        LLAMA_FN_HOST_ACC_INLINE auto getBlobNrAndOffset(UserDomain coord) const
+            -> NrAndOffset
         {
             const auto offset
                 = LinearBytePos<DatumDomain, DatumDomainCoord...>::value;

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -51,16 +51,13 @@ namespace llama::mapping
 
         /// \param size size of the user domain
         LLAMA_FN_HOST_ACC_INLINE
-        SoA(UserDomain const size) :
-                userDomainSize(size),
-                extentUserDomainAdress(
-                    ExtentUserDomainAdressFunctor{}(userDomainSize))
-        {}
+        SoA(UserDomain const size) : userDomainSize(size) {}
 
         LLAMA_FN_HOST_ACC_INLINE
         auto getBlobSize(std::size_t const) const -> std::size_t
         {
-            return extentUserDomainAdress * SizeOf<DatumDomain>::value;
+            return ExtentUserDomainAdressFunctor{}(
+                userDomainSize)*SizeOf<DatumDomain>::value;
         }
 
         template<std::size_t... DatumDomainCoord>
@@ -73,11 +70,10 @@ namespace llama::mapping
                     * sizeof(
                         GetType<DatumDomain, DatumCoord<DatumDomainCoord...>>)
                 + LinearBytePos<DatumDomain, DatumDomainCoord...>::value
-                    * extentUserDomainAdress;
+                    * ExtentUserDomainAdressFunctor{}(userDomainSize);
             return {0, offset};
         }
 
         const UserDomain userDomainSize;
-        const std::size_t extentUserDomainAdress;
     };
 }

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -27,13 +27,13 @@ namespace llama::mapping
     /** Struct of array mapping which can be used for creating a \ref View with
      * a \ref Factory. For the interface details see \ref Factory. \tparam
      * T_UserDomain type of the user domain \tparam T_DatumDomain type of the
-     * datum domain \tparam T_LinearizeUserDomainAdressFunctor Defines how the
+     * datum domain \tparam LinearizeUserDomainAdressFunctor Defines how the
      * user domain should be linearized, e.g. C like with the last dimension
      * being the "fast" one
      *  (\ref LinearizeUserDomainAdress, default) or Fortran like with the first
      *  dimension being the "fast" one (\ref
      * LinearizeUserDomainAdressLikeFortran). \tparam
-     * T_ExtentUserDomainAdressFunctor Defines how the size of the view shall be
+     * ExtentUserDomainAdressFunctor Defines how the size of the view shall be
      * created. Should fit for `T_LinearizeUserDomainAdressFunctor`. Only right
      * now implemented and default value is \ref ExtentUserDomainAdress. \see
      * AoS
@@ -41,8 +41,8 @@ namespace llama::mapping
     template<
         typename T_UserDomain,
         typename T_DatumDomain,
-        typename T_LinearizeUserDomainAdressFunctor = LinearizeUserDomainAdress,
-        typename T_ExtentUserDomainAdressFunctor = ExtentUserDomainAdress>
+        typename LinearizeUserDomainAdressFunctor = LinearizeUserDomainAdress,
+        typename ExtentUserDomainAdressFunctor = ExtentUserDomainAdress>
     struct SoA
     {
         using UserDomain = T_UserDomain;
@@ -54,7 +54,7 @@ namespace llama::mapping
         SoA(UserDomain const size) :
                 userDomainSize(size),
                 extentUserDomainAdress(
-                    T_ExtentUserDomainAdressFunctor()(userDomainSize))
+                    ExtentUserDomainAdressFunctor{}(userDomainSize))
         {}
 
         LLAMA_FN_HOST_ACC_INLINE
@@ -64,10 +64,12 @@ namespace llama::mapping
         }
 
         template<std::size_t... DatumDomainCoord>
-        auto getBlobNrAndOffset(UserDomain coord) const -> NrAndOffset
+        LLAMA_FN_HOST_ACC_INLINE auto getBlobNrAndOffset(UserDomain coord) const
+            -> NrAndOffset
         {
+            LLAMA_FORCE_INLINE_RECURSIVE
             const auto offset
-                = T_LinearizeUserDomainAdressFunctor()(coord, userDomainSize)
+                = LinearizeUserDomainAdressFunctor{}(coord, userDomainSize)
                     * sizeof(
                         GetType<DatumDomain, DatumCoord<DatumDomainCoord...>>)
                 + LinearBytePos<DatumDomain, DatumDomainCoord...>::value
@@ -75,7 +77,7 @@ namespace llama::mapping
             return {0, offset};
         }
 
-        UserDomain const userDomainSize;
-        std::size_t const extentUserDomainAdress;
+        const UserDomain userDomainSize;
+        const std::size_t extentUserDomainAdress;
     };
 }

--- a/include/llama/mapping/tree/Mapping.hpp
+++ b/include/llama/mapping/tree/Mapping.hpp
@@ -86,7 +86,8 @@ namespace llama::mapping::tree
         }
 
         template<std::size_t... DatumDomainCoord>
-        auto getBlobNrAndOffset(UserDomain coord) const -> NrAndOffset
+        LLAMA_FN_HOST_ACC_INLINE auto getBlobNrAndOffset(UserDomain coord) const
+            -> NrAndOffset
         {
             auto const basicTreeCoord
                 = getBasicTreeCoordFromDomains<DatumCoord<DatumDomainCoord...>>(

--- a/include/llama/preprocessor/macros.hpp
+++ b/include/llama/preprocessor/macros.hpp
@@ -78,10 +78,10 @@
  *  #include <llama/llama.hpp>
  * \endcode
  */
-#if BOOST_COMP_GNUC != 0
-#define LLAMA_FN_HOST_ACC_INLINE inline __attribute__((always_inline))
-#elif defined(BOOST_COMP_NVCC)
+#if BOOST_COMP_NVCC != 0
 #define LLAMA_FN_HOST_ACC_INLINE __forceinline__
+#elif BOOST_COMP_GNUC != 0
+#define LLAMA_FN_HOST_ACC_INLINE inline __attribute__((always_inline))
 #elif defined(_MSC_VER)
 #define LLAMA_FN_HOST_ACC_INLINE __forceinline
 #else

--- a/include/llama/preprocessor/macros.hpp
+++ b/include/llama/preprocessor/macros.hpp
@@ -80,6 +80,8 @@
  */
 #if BOOST_COMP_GNUC != 0
 #define LLAMA_FN_HOST_ACC_INLINE inline __attribute__((always_inline))
+#elif defined(BOOST_COMP_NVCC)
+#define LLAMA_FN_HOST_ACC_INLINE __forceinline__
 #elif defined(_MSC_VER)
 #define LLAMA_FN_HOST_ACC_INLINE __forceinline
 #else


### PR DESCRIPTION
Refactoring and removal of custom Alpaka allocator, which is replaced by Views not owning their underlying memory.

- [x] test the example with other Alpaka accelerators