### PR TITLE
Documentation improvements

### DIFF
--- a/examples/alpaka/asynccopy/asynccopy.cpp
+++ b/examples/alpaka/asynccopy/asynccopy.cpp
@@ -162,7 +162,7 @@ struct BlurKernel
         for(auto y = start[0]; y < end[0]; ++y) LLAMA_INDEPENDENT_DATA
         for(auto x = start[1]; x < end[1]; ++x)
         {
-            auto sum = llama::stackVirtualDatumAlloc<PixelOnAcc>();
+            auto sum = llama::allocVirtualDatumStack<PixelOnAcc>();
             sum = 0;
 
             using ItType = long int;

--- a/examples/alpaka/nbody/nbody.cpp
+++ b/examples/alpaka/nbody/nbody.cpp
@@ -109,7 +109,7 @@ struct UpdateKernel
                 // memory
                 if constexpr(BlockSize / Elems == 1)
                     return llama::allocViewStack<
-                        View::Mapping::UserDomain::count,
+                        View::Mapping::UserDomain::rank,
                         typename View::Mapping::DatumDomain>();
                 else
                 {
@@ -272,7 +272,7 @@ int main(int argc, char ** argv)
     LLAMA_INDEPENDENT_DATA
     for(std::size_t i = 0; i < PROBLEM_SIZE; ++i)
     {
-        auto temp = llama::stackVirtualDatumAlloc<Particle>();
+        auto temp = llama::allocVirtualDatumStack<Particle>();
         temp(tag::Pos(), tag::X()) = distribution(generator);
         temp(tag::Pos(), tag::Y()) = distribution(generator);
         temp(tag::Pos(), tag::Z()) = distribution(generator);

--- a/examples/simpletest/simpletest.cpp
+++ b/examples/simpletest/simpletest.cpp
@@ -159,7 +159,7 @@ int main(int argc, char ** argv)
               << std::endl;
     std::cout << "sizeOf DatumDomain: " << llama::sizeOf<Name> << std::endl;
 
-    std::cout << type(llama::GetCoordFromUID<Name, st::Pos, st::X>()) << '\n';
+    std::cout << type(llama::GetCoordFromTags<Name, st::Pos, st::X>()) << '\n';
 
     // chosing a native struct of array mapping for this simple test example
     using Mapping = llama::mapping::SoA<UD, Name>;

--- a/examples/vectoradd/vectoradd.cpp
+++ b/examples/vectoradd/vectoradd.cpp
@@ -104,7 +104,7 @@ namespace usellama
                       << "s\n";
         }
 
-        return (int)c.blob[0][0];
+        return (int)c.storageBlobs[0][0];
     }
 }
 

--- a/include/llama/Allocators.hpp
+++ b/include/llama/Allocators.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/Allocators.hpp
+++ b/include/llama/Allocators.hpp
@@ -27,27 +27,27 @@
 
 namespace llama::allocator
 {
+    /// Allocates stack memory for a \ref View, which is copied each time a \ref
+    /// View is copied.
+    /// \tparam BytesToReserve the amount of memory to reserve.
     template<std::size_t BytesToReserve>
     struct Stack
     {
-        LLAMA_FN_HOST_ACC_INLINE auto allocate(std::size_t) const
+        LLAMA_FN_HOST_ACC_INLINE auto operator()(std::size_t) const
             -> Array<std::byte, BytesToReserve>
         {
             return {};
         }
     };
 
-    /** Allocator to allocate memory for a \ref View in the \ref Factory using
-     *  `std::shared_ptr` in the background. Meaning every time the view is
-     * copied, the shared_ptr reference count is increased and both copies share
-     * the same memory! \tparam Alignment aligment of the memory used by
-     * `std::shared_ptr`, default value is 64
-     */
-    template<std::size_t Alignment = 64u>
+    /// Allocates heap memory managed by a `std::shared_ptr` for a \ref View.
+    /// This memory is shared between all copies of a \ref View.
+    /// \tparam Alignment aligment of the allocated block of memory.
+    template<std::size_t Alignment = 64>
     struct SharedPtr
     {
         LLAMA_NO_HOST_ACC_WARNING
-        inline auto allocate(std::size_t count) const
+        inline auto operator()(std::size_t count) const
             -> std::shared_ptr<std::byte[]>
         {
             auto * ptr = static_cast<std::byte *>(::operator new[](
@@ -108,18 +108,14 @@ namespace llama::allocator
         };
     }
 
-    /** Allocator to allocate memory for a \ref View in the \ref Factory using
-     *  `std::vector` in the background. Meaning every time the view is copied,
-     * the whole memory is copied. When the view is moved, the move operator of
-     *  `std::vector` is used.
-     * \tparam Alignment aligment of the memory used by `std::vector`, default
-     *  value is 64
-     */
+    /// Allocates heap memory managed by a `std::vector` for a \ref View, which
+    /// is copied each time a \ref View is copied.
+    /// \tparam Alignment aligment of the allocated block of memory.
     template<std::size_t Alignment = 64u>
     struct Vector
     {
         LLAMA_NO_HOST_ACC_WARNING
-        inline auto allocate(std::size_t count) const
+        inline auto operator()(std::size_t count) const
         {
             return std::vector<
                 std::byte,

--- a/include/llama/Array.hpp
+++ b/include/llama/Array.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/Array.hpp
+++ b/include/llama/Array.hpp
@@ -22,18 +22,15 @@
 
 namespace llama
 {
-    /** Array class like `std::array` but suitable for use with offloading
-     * devices like GPUs.
-     * \tparam T type if array elements
-     * \tparam Dim number of elements in array
-     * */
-    template<typename T, std::size_t Dim>
+    /// Array class like `std::array` but suitable for use with offloading
+    /// devices like GPUs.
+    /// \tparam T type if array elements.
+    /// \tparam N rank of the array.
+    template<typename T, std::size_t N>
     struct Array
     {
-        static constexpr std::size_t count
-            = Dim; ///< Number of elements in array
-        T element[count > 0 ? count : 1]; ///< Elements in the array, best to access with \ref
-                          ///< operator[].
+        static constexpr std::size_t rank = N;
+        T element[N > 0 ? N : 1];
 
         LLAMA_FN_HOST_ACC_INLINE T * begin()
         {
@@ -47,12 +44,12 @@ namespace llama
 
         LLAMA_FN_HOST_ACC_INLINE T * end()
         {
-            return &element[count];
+            return &element[N];
         };
 
         LLAMA_FN_HOST_ACC_INLINE const T * end() const
         {
-            return &element[count];
+            return &element[N];
         };
 
         template<typename IndexType>
@@ -69,19 +66,19 @@ namespace llama
         }
 
         LLAMA_FN_HOST_ACC_INLINE friend auto
-        operator==(const Array<T, Dim> & a, const Array<T, Dim> & b) -> bool
+        operator==(const Array<T, N> & a, const Array<T, N> & b) -> bool
         {
-            for(std::size_t i = 0; i < Dim; ++i)
+            for(std::size_t i = 0; i < N; ++i)
                 if(a.element[i] != b.element[i])
                     return false;
             return true;
         }
 
         LLAMA_FN_HOST_ACC_INLINE friend auto
-        operator+(const Array<T, Dim> & a, const Array<T, Dim> & b) -> Array
+        operator+(const Array<T, N> & a, const Array<T, N> & b) -> Array
         {
             Array temp;
-            for(std::size_t i = 0; i < Dim; ++i) temp[i] = a[i] + b[i];
+            for(std::size_t i = 0; i < N; ++i) temp[i] = a[i] + b[i];
             return temp;
         }
     };

--- a/include/llama/DatumCoord.hpp
+++ b/include/llama/DatumCoord.hpp
@@ -42,25 +42,21 @@ namespace llama
         using mp_unwrap_sizes = typename mp_unwrap_sizes_impl<L>::type;
     }
 
+    /// Converts a type list of integral constants into a \ref DatumCoord.
     template<typename L>
     using DatumCoordFromList = internal::mp_unwrap_sizes<L>;
 
-    /** Wrapper class for coordinate inside of datum domain tree.
-     * \tparam T_coords... the compile time coordinate
-     * */
+    /// Represents a coordinate for an element inside of datum domain tree.
+    /// \tparam Coords... the compile time coordinate.
     template<std::size_t... Coords>
     struct DatumCoord
     {
+        /// The list of integral coordinates as `boost::mp11::mp_list`.
         using List = boost::mp11::mp_list_c<std::size_t, Coords...>;
 
-        /// first coordinate element
         static constexpr std::size_t front = boost::mp11::mp_front<List>::value;
-
-        /// number of coordinate elements
-        static constexpr std::size_t size = sizeof...(Coords);
-
-        /// last ordinate
         static constexpr std::size_t back = boost::mp11::mp_back<List>::value;
+        static constexpr std::size_t size = sizeof...(Coords);
     };
 
     template<>
@@ -71,13 +67,13 @@ namespace llama
         static constexpr std::size_t size = 0;
     };
 
-    /// Concatenated two DatumCoords
+    /// Concatenate two \ref DatumCoords.
     template<typename DatumCoord1, typename DatumCoord2>
     using Cat = DatumCoordFromList<boost::mp11::mp_append<
         typename DatumCoord1::List,
         typename DatumCoord2::List>>;
 
-    /// DatumCoord without first coordinate element
+    /// DatumCoord without first coordinate component.
     template<typename DatumCoord>
     using PopFront = DatumCoordFromList<
         boost::mp11::mp_pop_front<typename DatumCoord::List>>;
@@ -110,11 +106,7 @@ namespace llama
         };
     }
 
-    /** Checks at compile time whether a first DatumCoord is bigger than a
-     * second. If so a static constexpr value will be set to true otherwise to
-     * false. \tparam First first \ref DatumCoord in the comparison \tparam
-     * Second second \ref DatumCoord in the comparison
-     * */
+    /// Checks wether the first DatumCoord is bigger than the second.
     template<typename First, typename Second>
     inline constexpr auto DatumCoordIsBigger
         = internal::DatumCoordIsBiggerImpl<First, Second>::value;
@@ -143,12 +135,8 @@ namespace llama
         };
     }
 
-    /** Checks at compile time whether a first DatumCoord is the same as a
-     * second. If so a static constexpr value will be set to true otherwise to
-     * false. \tparam First first \ref DatumCoord in the comparison \tparam
-     * Second second \ref DatumCoord in the comparison \tparam T_SFinae
-     * internal helper template parameter for specialization
-     * */
+    /// Checks wether two \ref DatumCoords are the same or one is the prefix of
+    /// the other.
     template<typename First, typename Second>
     inline constexpr auto DatumCoordIsSame
         = internal::DatumCoordIsSameImpl<First, Second>::value;

--- a/include/llama/DatumCoord.hpp
+++ b/include/llama/DatumCoord.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/ForEach.hpp
+++ b/include/llama/ForEach.hpp
@@ -43,7 +43,7 @@ namespace llama
                 InnerDatumCoord::size >= BaseDatumCoord::size
                 && DatumCoordIsSame<InnerDatumCoord, BaseDatumCoord>)
                 functor(
-                    BaseDatumCoord{},
+                    base,
                     DatumCoordFromList<boost::mp11::mp_drop_c<
                         typename InnerDatumCoord::List,
                         BaseDatumCoord::size>>{});
@@ -77,37 +77,37 @@ namespace llama
         }
     }
 
-    /** Can be used to access a given functor for every leaf in a datum domain
-     * given as \ref DatumStruct. Basically a helper function to iterate over a
-     * datum domain at compile time without the need to recursively iterate
-     * yourself. The given functor needs to implement the operator() with two
-     * template parameters for the outer and the inner coordinate in the datum
-     * domain tree. These coordinates are both a \ref DatumCoord , which can be
-     * concatenated to one coordinate with \ref Cat and used to
-     * access the data. \tparam DatumDomain the datum domain (\ref
-     * DatumStruct) to iterate over \tparam DatumCoordOrFirstUID DatumCoord or
-     * a UID to address the start node inside the datum domain tree. Will be
-     * given to the functor as \ref DatumCoord as first template parameter.
-     * \tparam RestUID... optional further UIDs for addressing the start node
-     */
-
+    /// Iterates over the datum domain tree and calls a functor on each element.
+    /// \param functor Functor to execute at each element of. Needs to have
+    /// `operator()` with two template parameters for the base and the inner
+    /// coordinate in the datum domain tree, both will be a spezialization of
+    /// \ref DatumCoord.
+    /// \param base \ref DatumCoord at which the iteration should be started.
+    /// The functor is called on elements beneath this coordinate.
     template<typename DatumDomain, typename Functor, std::size_t... Coords>
     LLAMA_FN_HOST_ACC_INLINE void
-    forEach(Functor && functor, DatumCoord<Coords...> coord)
+    forEach(Functor && functor, DatumCoord<Coords...> base)
     {
         LLAMA_FORCE_INLINE_RECURSIVE
         internal::applyFunctorForEachLeaf(
             DatumDomain{},
-            coord,
+            base,
             DatumCoord<>{},
             std::forward<Functor>(functor));
     }
 
-    template<typename DatumDomain, typename Functor, typename... UIDs>
-    LLAMA_FN_HOST_ACC_INLINE void forEach(Functor && functor, UIDs...)
+    /// Iterates over the datum domain tree and calls a functor on each element.
+    /// \param functor Functor to execute at each element of. Needs to have
+    /// `operator()` with two template parameters for the base and the inner
+    /// coordinate in the datum domain tree, both will be a spezialization of
+    /// \ref DatumCoord.
+    /// \param baseTags Tags used to define where the iteration should be
+    /// started. The functor is called on elements beneath this coordinate.
+    template<typename DatumDomain, typename Functor, typename... Tags>
+    LLAMA_FN_HOST_ACC_INLINE void forEach(Functor && functor, Tags... baseTags)
     {
         forEach<DatumDomain>(
             std::forward<Functor>(functor),
-            GetCoordFromUID<DatumDomain, UIDs...>{});
+            GetCoordFromTags<DatumDomain, Tags...>{});
     }
 }

--- a/include/llama/ForEach.hpp
+++ b/include/llama/ForEach.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/Functions.hpp
+++ b/include/llama/Functions.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/Functions.hpp
+++ b/include/llama/Functions.hpp
@@ -27,24 +27,18 @@
 
 namespace llama
 {
-    /** helper function to get the UID of a \ref DatumElement node
-     * \tparam DatumElement \ref DatumElement to get the UID of
-     * \return UID of the element
-     */
+    /// Get the tag from a \ref DatumElement.
     template<typename DatumElement>
-    using GetDatumElementUID = boost::mp11::mp_first<DatumElement>;
+    using GetDatumElementTag = boost::mp11::mp_first<DatumElement>;
 
-    /** helper function to get the type of a \ref DatumElement node
-     * \tparam DatumElement \ref DatumElement to get the type of
-     * \return type of the element
-     */
+    /// Get the type from a \ref DatumElement.
     template<typename DatumElement>
     using GetDatumElementType = boost::mp11::mp_second<DatumElement>;
 
     namespace internal
     {
         template<typename T, typename TargetDatumCoord, typename IterCoord>
-        constexpr auto linearBytePosImpl(T *, TargetDatumCoord, IterCoord)
+        constexpr auto offsetOfImpl(T *, TargetDatumCoord, IterCoord)
         {
             return sizeof(T)
                 * static_cast<std::size_t>(
@@ -55,7 +49,7 @@ namespace llama
             typename... DatumElements,
             typename TargetDatumCoord,
             std::size_t... IterCoords>
-        constexpr auto linearBytePosImpl(
+        constexpr auto offsetOfImpl(
             DatumStruct<DatumElements...> *,
             TargetDatumCoord,
             DatumCoord<IterCoords...>)
@@ -68,7 +62,7 @@ namespace llama
                 using Element = boost::mp11::
                     mp_at_c<DatumStruct<DatumElements...>, index>;
 
-                acc += linearBytePosImpl(
+                acc += offsetOfImpl(
                     (GetDatumElementType<Element> *)nullptr,
                     TargetDatumCoord{},
                     DatumCoord<IterCoords..., index>{});
@@ -77,37 +71,181 @@ namespace llama
         }
     }
 
-    /** Gives the byte position of an element in a datum domain if it would be a
-     *  normal struct
-     * \tparam DatumDomain datum domain tree
-     * \tparam Coords... coordinate in datum domain tree
-     */
-    template<typename DatumDomain, std::size_t... Coords>
-    inline constexpr std::size_t offsetOf = internal::linearBytePosImpl(
+    /// The byte offset of an element in a datum domain if it would be a normal
+    /// struct.
+    /// \tparam DatumDomain Datum domain tree.
+    /// \tparam ElementCoords... Components of a coordinate of an element in
+    /// datum domain tree.
+    template<typename DatumDomain, std::size_t... ElementCoords>
+    inline constexpr std::size_t offsetOf = internal::offsetOfImpl(
         (DatumDomain *)nullptr,
-        DatumCoord<Coords...>{},
+        DatumCoord<ElementCoords...>{},
         DatumCoord<>{});
 
-    /** Gives the size a datum domain if it would be a normal struct
-     * \tparam DatumDomain datum domain tree
-     * \return the byte position as compile time value in "value"
-     */
-    template<typename DatumDomain>
-    static constexpr auto sizeOf = sizeof(DatumDomain);
+    template<typename T>
+    static constexpr auto sizeOf = sizeof(T);
 
+    /// The size a datum domain if it would be a normal struct.
     template<typename... DatumElements>
     static constexpr auto sizeOf<DatumStruct<
         DatumElements...>> = (sizeOf<GetDatumElementType<DatumElements>> + ...);
 
     template<typename T>
-    inline constexpr auto IsDatumStruct = false;
+    inline constexpr auto isDatumStruct = false;
 
     template<typename... DatumElements>
-    inline constexpr auto IsDatumStruct<DatumStruct<DatumElements...>> = true;
+    inline constexpr auto isDatumStruct<DatumStruct<DatumElements...>> = true;
 
     namespace internal
     {
+        template<typename CurrTag, typename DatumDomain, typename DatumCoord>
+        struct GetTagImpl;
+
+        template<
+            typename CurrTag,
+            typename... DatumElements,
+            std::size_t FirstCoord,
+            std::size_t... Coords>
+        struct GetTagImpl<
+            CurrTag,
+            DatumStruct<DatumElements...>,
+            DatumCoord<FirstCoord, Coords...>>
+        {
+            using DatumElement = boost::mp11::
+                mp_at_c<boost::mp11::mp_list<DatumElements...>, FirstCoord>;
+            using ChildTag = GetDatumElementTag<DatumElement>;
+            using ChildType = GetDatumElementType<DatumElement>;
+            using type = typename GetTagImpl<
+                ChildTag,
+                ChildType,
+                DatumCoord<Coords...>>::type;
+        };
+
+        template<typename CurrTag, typename T>
+        struct GetTagImpl<CurrTag, T, DatumCoord<>>
+        {
+            using type = CurrTag;
+        };
+    }
+
+    /// Get the tag of the \ref DatumElement at a \ref DatumCoord inside the
+    /// datum domain tree.
+    template<typename DatumDomain, typename DatumCoord>
+    using GetTag =
+        typename internal::GetTagImpl<NoName, DatumDomain, DatumCoord>::type;
+
+    /// Is true if, starting at two coordinates in two datum domains, all
+    /// subsequent nodes in the datum domain tree have the same tag.
+    /// \tparam DatumDomainA First user domain.
+    /// \tparam StartA \ref DatumCoord where the comparison is started in the
+    /// first datum domain.
+    /// \tparam LocalA \ref DatumCoord based on StartA along which the tags are
+    /// compared.
+    /// \tparam DatumDomainB second user domain
+    /// \tparam StartB \ref DatumCoord where the comparison is started in the
+    /// second datum domain.
+    /// \tparam LocalB \ref DatumCoord based on StartB along which the tags are
+    /// compared.
+    template<
+        typename DatumDomainA,
+        typename StartA,
+        typename LocalA,
+        typename DatumDomainB,
+        typename StartB,
+        typename LocalB>
+    inline constexpr auto hasSameTags = false;
+
+    template<
+        typename DatumDomainA,
+        std::size_t... BaseCoordsA,
+        typename LocalA,
+        typename DatumDomainB,
+        std::size_t... BaseCoordsB,
+        typename LocalB>
+    inline constexpr auto hasSameTags<
+        DatumDomainA,
+        DatumCoord<BaseCoordsA...>,
+        LocalA,
+        DatumDomainB,
+        DatumCoord<BaseCoordsB...>,
+        LocalB> = []() constexpr
+    {
+        if constexpr(LocalA::size != LocalB::size)
+            return false;
+        else if constexpr(LocalA::size == 0 && LocalB::size == 0)
+            return true;
+        else
+        {
+            using TagCoordA = DatumCoord<BaseCoordsA..., LocalA::front>;
+            using TagCoordB = DatumCoord<BaseCoordsB..., LocalB::front>;
+
+            return std::is_same_v<
+                       GetTag<DatumDomainA, TagCoordA>,
+                       GetTag<
+                           DatumDomainB,
+                           TagCoordB>> && hasSameTags<DatumDomainA, TagCoordA, PopFront<LocalA>, DatumDomainB, TagCoordB, PopFront<LocalB>>;
+        }
+    }
+    ();
+
+    namespace internal
+    {
+        template<typename DatumDomain, typename DatumCoord, typename... Tags>
+        struct GetCoordFromTagsImpl
+        {
+            static_assert(
+                boost::mp11::mp_size<DatumDomain>::value != 0,
+                "Tag combination is not valid");
+        };
+
+        template<
+            typename... DatumElements,
+            std::size_t... ResultCoords,
+            typename FirstTag,
+            typename... Tags>
+        struct GetCoordFromTagsImpl<
+            DatumStruct<DatumElements...>,
+            DatumCoord<ResultCoords...>,
+            FirstTag,
+            Tags...>
+        {
+            template<typename DatumElement>
+            struct HasTag :
+                    std::is_same<GetDatumElementTag<DatumElement>, FirstTag>
+            {};
+
+            static constexpr auto tagIndex = boost::mp11::mp_find_if<
+                boost::mp11::mp_list<DatumElements...>,
+                HasTag>::value;
+            static_assert(
+                tagIndex < sizeof...(DatumElements),
+                "FirstTag was not found inside this DatumStruct");
+
+            using ChildType = GetDatumElementType<
+                boost::mp11::mp_at_c<DatumStruct<DatumElements...>, tagIndex>>;
+
+            using type = typename GetCoordFromTagsImpl<
+                ChildType,
+                DatumCoord<ResultCoords..., tagIndex>,
+                Tags...>::type;
+        };
+
         template<typename DatumDomain, typename DatumCoord>
+        struct GetCoordFromTagsImpl<DatumDomain, DatumCoord>
+        {
+            using type = DatumCoord;
+        };
+    }
+
+    /// Converts a series of tags navigating down a datum domain into a \ref
+    /// DatumCoord.
+    template<typename DatumDomain, typename... Tags>
+    using GetCoordFromTags = typename internal::
+        GetCoordFromTagsImpl<DatumDomain, DatumCoord<>, Tags...>::type;
+
+    namespace internal
+    {
+        template<typename DatumDomain, typename... DatumCoordOrTags>
         struct GetTypeImpl;
 
         template<
@@ -130,216 +268,51 @@ namespace llama
         {
             using type = T;
         };
+
+        template<typename DatumDomain, typename... DatumCoordOrTags>
+        struct GetTypeImpl
+        {
+            using type = typename GetTypeImpl<
+                DatumDomain,
+                GetCoordFromTags<DatumDomain, DatumCoordOrTags...>>::type;
+        };
     }
 
-    /** Returns the type of a node in a datum domain tree for a coordinate given
-     * as \ref DatumCoord \tparam DatumDomain the datum domain (probably \ref
-     * DatumStruct) \tparam DatumCoord the coordinate \return type at the
-     * specified node
-     */
-    template<typename DatumDomain, typename DatumCoord>
+    /// Returns the type of a node in a datum domain tree identified by a given
+    /// \ref DatumCoord or a series of tags.
+    template<typename DatumDomain, typename... DatumCoordOrTags>
     using GetType =
-        typename internal::GetTypeImpl<DatumDomain, DatumCoord>::type;
+        typename internal::GetTypeImpl<DatumDomain, DatumCoordOrTags...>::type;
 
     namespace internal
     {
-        template<typename CurrTag, typename DatumDomain, typename DatumCoord>
-        struct GetUIDImpl;
-
         template<
-            typename CurrTag,
-            typename... DatumElements,
-            std::size_t FirstCoord,
-            std::size_t... Coords>
-        struct GetUIDImpl<
-            CurrTag,
-            DatumStruct<DatumElements...>,
-            DatumCoord<FirstCoord, Coords...>>
+            typename DatumDomain,
+            typename BaseDatumCoord,
+            typename... Tags>
+        struct GetCoordFromTagsRelativeImpl
         {
-            using DatumElement = boost::mp11::
-                mp_at_c<boost::mp11::mp_list<DatumElements...>, FirstCoord>;
-            using ChildTag = GetDatumElementUID<DatumElement>;
-            using ChildType = GetDatumElementType<DatumElement>;
-            using type = typename GetUIDImpl<
-                ChildTag,
-                ChildType,
-                DatumCoord<Coords...>>::type;
-        };
-
-        template<typename CurrTag, typename T>
-        struct GetUIDImpl<CurrTag, T, DatumCoord<>>
-        {
-            using type = CurrTag;
-        };
-    }
-
-    /** return the unique identifier of the \ref DatumElement at a \ref
-     *  DatumCoord inside the datum domain tree.
-     * \tparam DatumDomain the datum domain, probably of type \ref DatumStruct
-     * or \ref DatumArray \tparam DatumCoord the datum coord, probably of type
-     * \ref DatumCoord \return unique identifer type
-     * */
-    template<typename DatumDomain, typename DatumCoord>
-    using GetUID =
-        typename internal::GetUIDImpl<NoName, DatumDomain, DatumCoord>::type;
-
-    /** Tells whether two coordinates in two datum domains have the same UID.
-     * \tparam DDA first user domain
-     * \tparam BaseA First part of the coordinate in the first user domain as
-     *  \ref DatumCoord. This will be used for getting the UID, but not for the
-     *  comparison.
-     * \tparam LocalA Second part of the coordinate in the first user domain
-     * as \ref DatumCoord. This will be used for the comparison with the second
-     *  datum domain.
-     * \tparam DDB second user domain
-     * \tparam BaseB First part of the coordinate in the second user domain as
-     *  \ref DatumCoord. This will be used for getting the UID, but not for the
-     *  comparison.
-     * \tparam LocalB Second part of the coordinate in the second user domain
-     * as \ref DatumCoord. This will be used for the comparison with the first
-     *  datum domain.
-     */
-    template<
-        typename DatumDomainA,
-        typename BaseA,
-        typename LocalA,
-        typename DatumDomainB,
-        typename BaseB,
-        typename LocalB>
-    inline constexpr auto CompareUID = false;
-
-    template<
-        typename DatumDomainA,
-        std::size_t... BaseCoordsA,
-        typename LocalA,
-        typename DatumDomainB,
-        std::size_t... BaseCoordsB,
-        typename LocalB>
-    inline constexpr auto CompareUID<
-        DatumDomainA,
-        DatumCoord<BaseCoordsA...>,
-        LocalA,
-        DatumDomainB,
-        DatumCoord<BaseCoordsB...>,
-        LocalB> = []() constexpr
-    {
-        if constexpr(LocalA::size != LocalB::size)
-            return false;
-        else if constexpr(LocalA::size == 0 && LocalB::size == 0)
-            return true;
-        else
-        {
-            using TagCoordA = DatumCoord<BaseCoordsA..., LocalA::front>;
-            using TagCoordB = DatumCoord<BaseCoordsB..., LocalB::front>;
-
-            return std::is_same_v<
-                       GetUID<DatumDomainA, TagCoordA>,
-                       GetUID<
-                           DatumDomainB,
-                           TagCoordB>> && CompareUID<DatumDomainA, TagCoordA, PopFront<LocalA>, DatumDomainB, TagCoordB, PopFront<LocalB>>;
-        }
-    }
-    ();
-
-    namespace internal
-    {
-        template<typename DatumDomain, typename DatumCoord, typename... UID>
-        struct GetCoordFromUIDImpl
-        {
-            static_assert(
-                boost::mp11::mp_size<DatumDomain>::value != 0,
-                "UID combination is not valid");
-        };
-
-        template<
-            typename... DatumElements,
-            std::size_t... ResultCoords,
-            typename FirstUID,
-            typename... UID>
-        struct GetCoordFromUIDImpl<
-            DatumStruct<DatumElements...>,
-            DatumCoord<ResultCoords...>,
-            FirstUID,
-            UID...>
-        {
-            template<typename DatumElement>
-            struct HasTag :
-                    std::is_same<GetDatumElementUID<DatumElement>, FirstUID>
-            {};
-
-            static constexpr auto tagIndex = boost::mp11::mp_find_if<
-                boost::mp11::mp_list<DatumElements...>,
-                HasTag>::value;
-            static_assert(
-                tagIndex < sizeof...(DatumElements),
-                "FirstUID was not found inside this DatumStruct");
-
-            using ChildType = GetDatumElementType<
-                boost::mp11::mp_at_c<DatumStruct<DatumElements...>, tagIndex>>;
-
-            using type = typename GetCoordFromUIDImpl<
-                ChildType,
-                DatumCoord<ResultCoords..., tagIndex>,
-                UID...>::type;
-        };
-
-        template<typename DatumDomain, typename DatumCoord>
-        struct GetCoordFromUIDImpl<DatumDomain, DatumCoord>
-        {
-            using type = DatumCoord;
-        };
-    }
-
-    /** Converts a coordinate in a datum domain given as UID to a \ref
-     * DatumCoord . \tparam DatumDomain the datum domain (\ref DatumStruct)
-     * \tparam UID... the uid of in the datum domain, may also be empty (for
-     *  `DatumCoord< >`)
-     * \returns a \ref DatumCoord with the datum domain tree coordinates as
-     * template parameters
-     */
-    template<typename DatumDomain, typename... UID>
-    using GetCoordFromUID = typename internal::
-        GetCoordFromUIDImpl<DatumDomain, DatumCoord<>, UID...>::type;
-
-    namespace internal
-    {
-        template<typename DatumDomain, typename DatumCoord, typename... UID>
-        struct GetCoordFromUIDRelativeImpl
-        {
-            using AbsolutCoord = typename internal::GetCoordFromUIDImpl<
-                GetType<DatumDomain, DatumCoord>,
-                DatumCoord,
-                UID...>::type;
-            // Only returning the datum coord relative to DatumCoord
+            using AbsolutCoord = typename internal::GetCoordFromTagsImpl<
+                GetType<DatumDomain, BaseDatumCoord>,
+                BaseDatumCoord,
+                Tags...>::type;
+            // Only returning the datum coord relative to BaseDatumCoord
             using type = DatumCoordFromList<boost::mp11::mp_drop_c<
                 typename AbsolutCoord::List,
-                DatumCoord::size>>;
+                BaseDatumCoord::size>>;
         };
     }
 
-    /** Converts a coordinate in a datum domain given as UID to a \ref
-     * DatumCoord relative to a given datum coord in the tree. The returned
-     * datum coord is also relative to the input datum coord, that is the sub
-     * tree. \tparam DatumDomain the datum domain (\ref DatumStruct) \tparam
-     * DatumCoord datum coord to start the translation from UID to datum coord
-     * \tparam UID... the uid of in the datum domain, may also be empty (for
-     *  `DatumCoord< >`)
-     * \returns a \ref DatumCoord with the datum domain tree coordinates as
-     * template parameters
-     */
-    template<typename DatumDomain, typename DatumCoord, typename... UID>
-    using GetCoordFromUIDRelative = typename internal::
-        GetCoordFromUIDRelativeImpl<DatumDomain, DatumCoord, UID...>::type;
+    /// Converts a series of tags navigating down a datum domain, starting at a
+    /// given \ref DatumCoord, into a \ref DatumCoord.
+    template<typename DatumDomain, typename BaseDatumCoord, typename... Tags>
+    using GetCoordFromTagsRelative =
+        typename internal::GetCoordFromTagsRelativeImpl<
+            DatumDomain,
+            BaseDatumCoord,
+            Tags...>::type;
 
-    /** Returns the type of a node in a datum domain tree for a coordinate given
-     * as UID \tparam DatumDomain the datum domain (probably \ref DatumStruct)
-     * \tparam DatumCoord the coordinate
-     * \return type at the specified node
-     */
-    template<typename DatumDomain, typename... UIDs>
-    using GetTypeFromUID
-        = GetType<DatumDomain, GetCoordFromUID<DatumDomain, UIDs...>>;
-
+    /// Iterator supporting \ref UserDomainCoordRange.
     template<std::size_t Dim>
     struct UserDomainCoordIterator :
             boost::iterator_facade<
@@ -379,6 +352,7 @@ namespace llama
         UserDomain<Dim> current;
     };
 
+    /// Range allowing to iterate over all indices in a \ref UserDomain.
     template<std::size_t Dim>
     struct UserDomainCoordRange
     {

--- a/include/llama/Tuple.hpp
+++ b/include/llama/Tuple.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/Types.hpp
+++ b/include/llama/Types.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/Types.hpp
+++ b/include/llama/Types.hpp
@@ -25,16 +25,13 @@
 
 namespace llama
 {
-    /** Anonymous naming for a \ref DatumElement. Especially used for a \ref
-     *  DatumArray. Two DatumElements with the same identifier llama::NoName
-     * will not match.
-     * */
+    /// Anonymous naming for a \ref DatumElement. Especially used for a \ref
+    /// DatumArray.
     struct NoName
     {};
 
-    /** The run-time specified user domain
-     * \tparam Dim compile time dimensionality of the user domain
-     * */
+    /// The run-time specified user domain.
+    /// \tparam Dim compile time dimensionality of the user domain
     template<std::size_t Dim>
     struct UserDomain : Array<std::size_t, Dim>
     {};
@@ -44,31 +41,28 @@ namespace llama
                                    // coord. Should hold for all dimensions, but
                                    // just checking for <1> here.
 
-    /** A list of \ref DatumElement which may be used to define a datum domain.
-     * \tparam Leaves... List of \ref DatumElement
-     * */
+    /// A list of \ref DatumElement which may be used to define a datum domain.
     template<typename... Leaves>
     using DatumStruct = boost::mp11::mp_list<Leaves...>;
 
-    /// Shortcut for \ref DatumStruct
+    /// Shortcut alias for \ref DatumStruct.
     template<typename... Leaves>
     using DS = DatumStruct<Leaves...>;
 
-    /** Datum domain tree node which may either a leaf or refer to a child tree
-     *  presented as another \ref DatumStruct.
-     * \tparam Identifier Name of the node. May be any type (struct, class).
-     * \ref llama::NoName is considered a special identifier, which never
-     * matches. \tparam Type Type of the node. May be either another sub tree
-     * consisting of a nested \ref DatumStruct or any other type making it a
-     * leaf of this type.
-     * */
-    template<typename Identifier, typename Type>
-    using DatumElement = boost::mp11::mp_list<Identifier, Type>;
+    /// Datum domain tree node which may either be a leaf or refer to a child
+    /// tree presented as another \ref DatumStruct or \ref DatumArray.
+    /// \tparam Tag Name of the node. May be any type (struct, class).
+    /// \tparam Type Type of the node. May be either another sub tree consisting
+    /// of a nested \ref DatumStruct or \ref DatumArray or any other type making
+    /// it a leaf of this type.
+    template<typename Tag, typename Type>
+    using DatumElement = boost::mp11::mp_list<Tag, Type>;
 
-    /// Shortcut for \ref DatumElement
+    /// Shortcut alias for \ref DatumElement.
     template<typename Identifier, typename Type>
     using DE = DatumElement<Identifier, Type>;
 
+    /// Tag describing an index. Used to access members of a \ref DatumArray.
     template<std::size_t I>
     using Index = boost::mp11::mp_size_t<I>;
 
@@ -81,17 +75,18 @@ namespace llama
         }
     }
 
-    /** An array of anonymous but identical \ref DatumElement "DatumElements".
-     * Can be used anywhere where \ref DatumStruct may used. \tparam ChildType
-     * type to repeat. May be either another sub tree consisting of a nested
-     * \ref DatumStruct resp. DatumArray or any other type making it an array of
-     * leaves of this type. \tparam Count number of repetitions of ChildType
-     * */
+    /// An array of identical \ref DatumElement with \ref Index specialized on
+    /// consecutive numbers. Can be used anywhere where \ref DatumStruct may
+    /// used.
+    /// \tparam ChildType Type to repeat. May be either a nested \ref
+    /// DatumStruct or DatumArray or any other type making it an array of leaves
+    /// of this type.
+    /// \tparam Count Number of repetitions of ChildType.
     template<typename ChildType, std::size_t Count>
     using DatumArray = decltype(
         internal::makeDatumArray<ChildType>(std::make_index_sequence<Count>{}));
 
-    /// Shortcut for \ref DatumArray
+    /// Shortcut alias for \ref DatumArray
     template<typename ChildType, std::size_t Count>
     using DA = DatumArray<ChildType, Count>;
 

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes, Rene Widera
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -36,8 +36,7 @@ namespace llama
     namespace internal
     {
         template<typename Allocator>
-        using AllocatorBlobType
-            = decltype(std::declval<Allocator>().allocate(0));
+        using AllocatorBlobType = decltype(std::declval<Allocator>()(0));
 
         template<typename Allocator, typename Mapping, std::size_t... Is>
         LLAMA_FN_HOST_ACC_INLINE static auto makeBlobArray(
@@ -46,16 +45,15 @@ namespace llama
             std::integer_sequence<std::size_t, Is...>)
             -> Array<AllocatorBlobType<Allocator>, Mapping::blobCount>
         {
-            return {alloc.allocate(mapping.getBlobSize(Is))...};
+            return {alloc(mapping.getBlobSize(Is))...};
         }
     }
 
-    /** Creates a view based on the given mapping, e.g. \ref mapping::AoS or
-     * \ref mapping::SoA. For allocating the view's underlying memory, the
-     * specified allocator is used (or the default one, which is \ref
-     * allocator::Vector). This function is the preferred way to create a \ref
-     * View.
-     */
+    /// Creates a view based on the given mapping, e.g. \ref mapping::AoS or
+    /// \ref mapping::SoA. For allocating the view's underlying memory, the
+    /// specified allocator is used (or the default one, which is \ref
+    /// allocator::Vector). This function is the preferred way to create a \ref
+    /// View.
     template<typename Mapping, typename Allocator = allocator::Vector<>>
     LLAMA_FN_HOST_ACC_INLINE auto
     allocView(Mapping mapping = {}, const Allocator & alloc = {})
@@ -69,12 +67,9 @@ namespace llama
                 std::make_index_sequence<Mapping::blobCount>{})};
     }
 
-    /** Uses the \ref OneOnStackFactory to allocate one (probably temporary)
-     * element for a given dimension and datum domain on the stack (no costly
-     * allocation). \tparam Dimension dimension of the view \tparam DatumDomain
-     * the datum domain for the one element mapping \return the allocated view
-     * \see OneOnStackFactory
-     */
+    /// Allocates a \ref View holding a single datum backed by stack memory
+    /// (\ref allocator::Stack).
+    /// \tparam Dim Dimension of the \ref UserDomain of the \ref View.
     template<std::size_t Dim, typename DatumDomain>
     LLAMA_FN_HOST_ACC_INLINE auto allocViewStack() -> decltype(auto)
     {
@@ -117,13 +112,9 @@ namespace llama
     inline constexpr auto
         is_VirtualDatum<VirtualDatum<View, BoundDatumDomain, OwnView>> = true;
 
-    /** Uses the \ref allocViewStack to allocate a virtual datum with an own
-     * bound view "allocated" on the stack. \tparam DatumDomain the datum
-     * domain for the virtual datum \return the allocated virtual datum \see
-     * allocViewStack
-     */
+    /// Creates a single \ref VirtualDatum owning a view with stack memory.
     template<typename DatumDomain>
-    LLAMA_FN_HOST_ACC_INLINE auto stackVirtualDatumAlloc() -> VirtualDatum<
+    LLAMA_FN_HOST_ACC_INLINE auto allocVirtualDatumStack() -> VirtualDatum<
         decltype(llama::allocViewStack<1, DatumDomain>()),
         DatumCoord<>,
         true>
@@ -131,391 +122,251 @@ namespace llama
         return {UserDomain<1>{}, llama::allocViewStack<1, DatumDomain>()};
     }
 
-    /** Uses the \ref stackVirtualDatumAlloc to allocate a virtual datum with an
-     * own bound view "allocated" on the stack bases on an existing virtual
-     * datum, whose data is copied into the new virtual datum. \tparam
-     * VirtualDatum type of the input virtual datum \return the virtual datum
-     * copy on stack \see stackVirtualDatumAlloc
-     */
+    /// Creates a single \ref VirtualDatum owning a view with stack memory and
+    /// copies all values from an existing \ref VirtualDatum.
     template<typename VirtualDatum>
-    LLAMA_FN_HOST_ACC_INLINE auto stackVirtualDatumCopy(const VirtualDatum & vd)
+    LLAMA_FN_HOST_ACC_INLINE auto copyVirtualDatumStack(const VirtualDatum & vd)
         -> decltype(auto)
     {
-        auto temp = stackVirtualDatumAlloc<
+        auto temp = allocVirtualDatumStack<
             typename VirtualDatum::AccessibleDatumDomain>();
         temp = vd;
         return temp;
     }
 
-    template<
-        typename LeftDatum,
-        typename RightDatum,
-        typename Source,
-        typename LeftOuterCoord,
-        typename LeftInnerCoord,
-        typename OP>
-    struct GenericInnerFunctor
+    namespace internal
     {
-        template<typename RightOuterCoord, typename RightInnerCoord>
-        LLAMA_FN_HOST_ACC_INLINE void
-        operator()(RightOuterCoord, RightInnerCoord)
+        template<
+            typename LeftDatum,
+            typename RightDatum,
+            typename Source,
+            typename LeftOuterCoord,
+            typename LeftInnerCoord,
+            typename OP>
+        struct GenericInnerFunctor
         {
-            if constexpr(CompareUID<
-                             typename LeftDatum::AccessibleDatumDomain,
-                             LeftOuterCoord,
-                             LeftInnerCoord,
-                             typename RightDatum::AccessibleDatumDomain,
-                             RightOuterCoord,
-                             RightInnerCoord>)
+            template<typename RightOuterCoord, typename RightInnerCoord>
+            LLAMA_FN_HOST_ACC_INLINE void
+            operator()(RightOuterCoord, RightInnerCoord)
             {
-                using Dst = Cat<LeftOuterCoord, LeftInnerCoord>;
-                using Src = Cat<RightOuterCoord, RightInnerCoord>;
-                OP{}(left(Dst()), right(Src()));
+                if constexpr(hasSameTags<
+                                 typename LeftDatum::AccessibleDatumDomain,
+                                 LeftOuterCoord,
+                                 LeftInnerCoord,
+                                 typename RightDatum::AccessibleDatumDomain,
+                                 RightOuterCoord,
+                                 RightInnerCoord>)
+                {
+                    using Dst = Cat<LeftOuterCoord, LeftInnerCoord>;
+                    using Src = Cat<RightOuterCoord, RightInnerCoord>;
+                    OP{}(left(Dst()), right(Src()));
+                }
             }
-        }
-        LeftDatum & left;
-        const RightDatum & right;
-    };
+            LeftDatum & left;
+            const RightDatum & right;
+        };
 
-    template<
-        typename LeftDatum,
-        typename RightDatum,
-        typename SourceDatumCoord,
-        typename OP>
-    struct GenericFunctor
-    {
-        template<typename LeftOuterCoord, typename LeftInnerCoord>
-        LLAMA_FN_HOST_ACC_INLINE void operator()(LeftOuterCoord, LeftInnerCoord)
+        template<
+            typename LeftDatum,
+            typename RightDatum,
+            typename SourceDatumCoord,
+            typename OP>
+        struct GenericFunctor
         {
-            forEach<typename RightDatum::AccessibleDatumDomain>(
-                GenericInnerFunctor<
+            template<typename LeftOuterCoord, typename LeftInnerCoord>
+            LLAMA_FN_HOST_ACC_INLINE void
+            operator()(LeftOuterCoord, LeftInnerCoord)
+            {
+                forEach<typename RightDatum::AccessibleDatumDomain>(
+                    GenericInnerFunctor<
+                        LeftDatum,
+                        RightDatum,
+                        SourceDatumCoord,
+                        LeftOuterCoord,
+                        LeftInnerCoord,
+                        OP>{left, right},
+                    SourceDatumCoord{});
+            }
+            LeftDatum & left;
+            const RightDatum & right;
+        };
+
+        template<typename LeftDatum, typename RightType, typename OP>
+        struct GenericTypeFunctor
+        {
+            template<typename OuterCoord, typename InnerCoord>
+            LLAMA_FN_HOST_ACC_INLINE void operator()(OuterCoord, InnerCoord)
+            {
+                using Dst = Cat<OuterCoord, InnerCoord>;
+                OP{}(left(Dst()), right);
+            }
+            LeftDatum & left;
+            const RightType & right;
+        };
+    }
+
+    namespace internal
+    {
+        template<
+            typename LeftDatum,
+            typename LeftBase,
+            typename LeftLocal,
+            typename RightDatum,
+            typename OP>
+        struct GenericBoolInnerFunctor
+        {
+            template<typename OuterCoord, typename InnerCoord>
+            LLAMA_FN_HOST_ACC_INLINE void operator()(OuterCoord, InnerCoord)
+            {
+                if constexpr(hasSameTags<
+                                 typename LeftDatum::View::Mapping::DatumDomain,
+                                 LeftBase,
+                                 LeftLocal,
+                                 typename RightDatum::View::Mapping::
+                                     DatumDomain,
+                                 OuterCoord,
+                                 InnerCoord>)
+                {
+                    using Dst = Cat<LeftBase, LeftLocal>;
+                    using Src = Cat<OuterCoord, InnerCoord>;
+                    result &= OP{}(left(Dst()), right(Src()));
+                }
+            }
+            const LeftDatum & left;
+            const RightDatum & right;
+            bool result;
+        };
+
+        template<
+            typename LeftDatum,
+            typename RightDatum,
+            typename SourceDatumCoord,
+            typename OP>
+        struct GenericBoolFunctor
+        {
+            template<typename OuterCoord, typename InnerCoord>
+            LLAMA_FN_HOST_ACC_INLINE void operator()(OuterCoord, InnerCoord)
+            {
+                GenericBoolInnerFunctor<
                     LeftDatum,
+                    OuterCoord,
+                    InnerCoord,
                     RightDatum,
-                    SourceDatumCoord,
-                    LeftOuterCoord,
-                    LeftInnerCoord,
-                    OP>{left, right},
-                SourceDatumCoord{});
-        }
-        LeftDatum & left;
-        const RightDatum & right;
-    };
-
-    template<typename LeftDatum, typename RightType, typename OP>
-    struct GenericTypeFunctor
-    {
-        template<typename OuterCoord, typename InnerCoord>
-        LLAMA_FN_HOST_ACC_INLINE void operator()(OuterCoord, InnerCoord)
-        {
-            using Dst = Cat<OuterCoord, InnerCoord>;
-            OP{}(left(Dst()), right);
-        }
-        LeftDatum & left;
-        const RightType & right;
-    };
-
-    /** Macro that defines an operator overloading inside of \ref
-     * llama::VirtualDatum for itself and a second virtual datum. \param OP
-     * operator, e.g. operator += \param FUNCTOR used for calling the internal
-     * needed functor to operate on the virtual datums, e.g. if FUNCTOR is
-     * "Addition", the AdditionFunctor will be used internally. \param REF may
-     * be & or && to determine whether it is an overloading for lvalue or rvalue
-     * references
-     * */
-    /** Macro that defines an operator overloading inside of \ref
-     * llama::VirtualDatum for itself and a view. Internally the virtual datum
-     * at the first postion (all zeros) will be taken. This is useful for
-     * one-element views (e.g. temporary views). \param OP operator, e.g.
-     * operator += \param FUNCTOR used for calling the internal needed functor
-     * to operate on the virtual datums, e.g. if FUNCTOR is "Addition", the
-     * AdditionFunctor will be used internally. \param REF may be & or && to
-     * determine whether it is an overloading for lvalue or rvalue references
-     * */
-    /** Macro that defines an operator overloading inside of \ref
-     * llama::VirtualDatum for itself and some other type. \param OP operator,
-     * e.g. operator += \param FUNCTOR used for calling the internal needed
-     * functor to operate on the virtual datums, e.g. if FUNCTOR is "Addition",
-     * the AdditionTypeFunctor will be used internally. \param REF may be & or
-     * && to determine whether it is an overloading for lvalue or rvalue
-     * references
-     * */
-#define __LLAMA_VIRTUALDATUM_OPERATOR(OP, FUNCTOR) \
-    template< \
-        typename OtherView, \
-        typename OtherBoundDatumDomain, \
-        bool OtherOwnView> \
-    LLAMA_FN_HOST_ACC_INLINE auto operator OP( \
-        const VirtualDatum<OtherView, OtherBoundDatumDomain, OtherOwnView> & \
-            other) \
-        ->VirtualDatum & \
-    { \
-        GenericFunctor< \
-            std::remove_reference_t<decltype(*this)>, \
-            VirtualDatum<OtherView, OtherBoundDatumDomain, OtherOwnView>, \
-            DatumCoord<>, \
-            FUNCTOR> \
-            functor{*this, other}; \
-        forEach<AccessibleDatumDomain>(functor); \
-        return *this; \
-    } \
-\
-    template<typename OtherMapping, typename OtherBlobType> \
-    LLAMA_FN_HOST_ACC_INLINE auto operator OP( \
-        const llama::View<OtherMapping, OtherBlobType> & other) \
-        ->VirtualDatum & \
-    { \
-        return *this OP other( \
-            llama::UserDomain<OtherMapping::UserDomain::count>{}); \
-    } \
-\
-    template< \
-        typename OtherType, \
-        typename \
-        = std::enable_if_t<!IsView<OtherType> && !is_VirtualDatum<OtherType>>> \
-    LLAMA_FN_HOST_ACC_INLINE auto operator OP(const OtherType & other) \
-        ->VirtualDatum & \
-    { \
-        GenericTypeFunctor<decltype(*this), OtherType, FUNCTOR> functor{ \
-            *this, other}; \
-        forEach<AccessibleDatumDomain>(functor); \
-        return *this; \
-    }
-
-    template<
-        typename LeftDatum,
-        typename LeftBase,
-        typename LeftLocal,
-        typename RightDatum,
-        typename OP>
-    struct GenericBoolInnerFunctor
-    {
-        template<typename OuterCoord, typename InnerCoord>
-        LLAMA_FN_HOST_ACC_INLINE void operator()(OuterCoord, InnerCoord)
-        {
-            if constexpr(CompareUID<
-                             typename LeftDatum::Mapping::DatumDomain,
-                             LeftBase,
-                             LeftLocal,
-                             typename RightDatum::Mapping::DatumDomain,
-                             OuterCoord,
-                             InnerCoord>)
-            {
-                using Dst = Cat<LeftBase, LeftLocal>;
-                using Src = Cat<OuterCoord, InnerCoord>;
-                result &= OP{}(left(Dst()), right(Src()));
+                    OP>
+                    functor{left, right, true};
+                forEach<typename RightDatum::AccessibleDatumDomain>(
+                    functor, SourceDatumCoord{});
+                result &= functor.result;
             }
-        }
-        const LeftDatum & left;
-        const RightDatum & right;
-        bool result;
-    };
+            const LeftDatum & left;
+            const RightDatum & right;
+            bool result;
+        };
 
-    template<
-        typename LeftDatum,
-        typename RightDatum,
-        typename SourceDatumCoord,
-        typename OP>
-    struct GenericBoolFunctor
-    {
-        template<typename OuterCoord, typename InnerCoord>
-        LLAMA_FN_HOST_ACC_INLINE void operator()(OuterCoord, InnerCoord)
+        template<typename LeftDatum, typename RightType, typename OP>
+        struct GenericBoolTypeFunctor
         {
-            GenericBoolInnerFunctor<
-                LeftDatum,
-                OuterCoord,
-                InnerCoord,
-                RightDatum,
-                OP>
-                functor{left, right, true};
-            forEach<typename RightDatum::AccessibleDatumDomain>(
-                functor, SourceDatumCoord{});
-            result &= functor.result;
-        }
-        const LeftDatum & left;
-        const RightDatum & right;
-        bool result;
-    };
-
-    template<typename LeftDatum, typename RightType, typename OP>
-    struct GenericBoolTypeFunctor
-    {
-        template<typename OuterCoord, typename InnerCoord>
-        LLAMA_FN_HOST_ACC_INLINE void operator()(OuterCoord, InnerCoord)
-        {
-            using Dst = Cat<OuterCoord, InnerCoord>;
-            result &= OP{}(
-                left(Dst()),
-                static_cast<std::remove_reference_t<decltype(left(Dst()))>>(
-                    right));
-        }
-        const LeftDatum & left;
-        const RightType & right;
-        bool result;
-    };
-
-/** Macro that defines a boolean operator overloading inside of
- *  \ref llama::VirtualDatum for itself and a second virtual datum.
- * \param OP operator, e.g. operator >=
- * \param FUNCTOR used for calling the internal needed functor to operate on
- *        the virtual datums, e.g. if FUNCTOR is "BiggerSameThan", the
- *        BiggerSameThanBoolFunctor will be used internally.
- * \param REF may be & or && to determine whether it is an overloading for
- *        lvalue or rvalue references
- * \return result of the boolean operation for every combination with the same
- *  UID
- * */
-/** Macro that defines a boolean operator overloading inside of
- *  \ref llama::VirtualDatum for itself and a view. Internally the virtual datum
- * at the first postion (all zeros) will be taken. This is useful for
- * one-element views (e.g. temporary views). \param OP operator, e.g. operator
- * >= \param FUNCTOR used for calling the internal needed functor to operate on
- *        the virtual datums, e.g. if FUNCTOR is "BiggerSameThan", the
- *        BiggerSameThanBoolFunctor will be used internally.
- * \param REF may be & or && to determine whether it is an overloading for
- *        lvalue or rvalue references
- * \return result of the boolean operation for every combination with the same
- *  UID
- * */
-/** Macro that defines a boolean operator overloading inside of
- *  \ref llama::VirtualDatum for itself and some other type.
- * \param OP operator, e.g. operator >=
- * \param FUNCTOR used for calling the internal needed functor to operate on
- *        the virtual datums, e.g. if FUNCTOR is "BiggerSameThan", the
- *        BiggerSameThanBoolTypeFunctor will be used internally.
- * \param REF may be & or && to determine whether it is an overloading for
- *        lvalue or rvalue references
- * \return result of the boolean operation for every combination
- * */
-#define __LLAMA_VIRTUALDATUM_BOOL_OPERATOR(OP, FUNCTOR) \
-    template< \
-        typename OtherView, \
-        typename OtherBoundDatumDomain, \
-        bool OtherOwnView> \
-    LLAMA_FN_HOST_ACC_INLINE auto operator OP( \
-        const VirtualDatum<OtherView, OtherBoundDatumDomain, OtherOwnView> & \
-            other) const->bool \
-    { \
-        GenericBoolFunctor< \
-            std::remove_reference_t<decltype(*this)>, \
-            VirtualDatum<OtherView, OtherBoundDatumDomain, OtherOwnView>, \
-            DatumCoord<>, \
-            FUNCTOR> \
-            functor{*this, other, true}; \
-        forEach<AccessibleDatumDomain>(functor); \
-        return functor.result; \
-    } \
-\
-    template<typename OtherMapping, typename OtherBlobType> \
-    LLAMA_FN_HOST_ACC_INLINE auto operator OP( \
-        const llama::View<OtherMapping, OtherBlobType> & other) const->bool \
-    { \
-        return *this OP other( \
-            llama::UserDomain<OtherMapping::UserDomain::count>{}); \
-    } \
-\
-    template<typename OtherType> \
-    LLAMA_FN_HOST_ACC_INLINE auto operator OP(const OtherType & other) \
-        const->bool \
-    { \
-        GenericBoolTypeFunctor<decltype(*this), OtherType, FUNCTOR> functor{ \
-            *this, other, true}; \
-        forEach<AccessibleDatumDomain>(functor); \
-        return functor.result; \
+            template<typename OuterCoord, typename InnerCoord>
+            LLAMA_FN_HOST_ACC_INLINE void operator()(OuterCoord, InnerCoord)
+            {
+                using Dst = Cat<OuterCoord, InnerCoord>;
+                result &= OP{}(
+                    left(Dst()),
+                    static_cast<std::remove_reference_t<decltype(left(Dst()))>>(
+                        right));
+            }
+            const LeftDatum & left;
+            const RightType & right;
+            bool result;
+        };
     }
 
-    struct Assignment
+    namespace internal
     {
-        template<typename A, typename B>
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto)
-        operator()(A & a, const B & b) const
+        struct Assign
         {
-            return a = b;
-        }
-    };
+            template<typename A, typename B>
+            LLAMA_FN_HOST_ACC_INLINE decltype(auto)
+            operator()(A & a, const B & b) const
+            {
+                return a = b;
+            }
+        };
 
-    struct Addition
-    {
-        template<typename A, typename B>
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto)
-        operator()(A & a, const B & b) const
+        struct PlusAssign
         {
-            return a += b;
-        }
-    };
+            template<typename A, typename B>
+            LLAMA_FN_HOST_ACC_INLINE decltype(auto)
+            operator()(A & a, const B & b) const
+            {
+                return a += b;
+            }
+        };
 
-    struct Subtraction
-    {
-        template<typename A, typename B>
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto)
-        operator()(A & a, const B & b) const
+        struct MinusAssign
         {
-            return a -= b;
-        }
-    };
+            template<typename A, typename B>
+            LLAMA_FN_HOST_ACC_INLINE decltype(auto)
+            operator()(A & a, const B & b) const
+            {
+                return a -= b;
+            }
+        };
 
-    struct Multiplication
-    {
-        template<typename A, typename B>
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto)
-        operator()(A & a, const B & b) const
+        struct MultiplyAssign
         {
-            return a *= b;
-        }
-    };
+            template<typename A, typename B>
+            LLAMA_FN_HOST_ACC_INLINE decltype(auto)
+            operator()(A & a, const B & b) const
+            {
+                return a *= b;
+            }
+        };
 
-    struct Division
-    {
-        template<typename A, typename B>
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto)
-        operator()(A & a, const B & b) const
+        struct DivideAssign
         {
-            return a /= b;
-        }
-    };
+            template<typename A, typename B>
+            LLAMA_FN_HOST_ACC_INLINE decltype(auto)
+            operator()(A & a, const B & b) const
+            {
+                return a /= b;
+            }
+        };
 
-    struct Modulo
-    {
-        template<typename A, typename B>
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto)
-        operator()(A & a, const B & b) const
+        struct ModuloAssign
         {
-            return a %= b;
-        }
-    };
-
-    template<typename T>
-    auto as_mutable(const T & t) -> T &
-    {
-        return const_cast<T &>(t);
+            template<typename A, typename B>
+            LLAMA_FN_HOST_ACC_INLINE decltype(auto)
+            operator()(A & a, const B & b) const
+            {
+                return a %= b;
+            }
+        };
     }
 
-    /** Virtual data type returned by \ref View after resolving user domain
-     * address, being "virtual" in that sense that the data of the virtual datum
-     * are not part of the struct itself but a helper object to address them in
-     * the compile time datum domain. Beside the user domain, also a part of the
-     * compile time domain may be resolved for access like `datum( Pos ) +=
-     * datum( Vel )`. \tparam T_View parent view of the virtual datum \tparam
-     * BoundDatumDomain optional \ref DatumCoord which restricts the virtual
-     * datum to a smaller part of the datum domain
-     */
+    /// Virtual data type returned by \ref View after resolving a user domain
+    /// coordinate or partially resolving a \ref DatumCoord. A virtual datum
+    /// does not hold data itself (thus named "virtual"), it just binds enough
+    /// information (user domain coord and partial datum coord) to retrieve it
+    /// from a \ref View later. Virtual datums should not be created by the
+    /// user. They are returned from various access functions in \ref View and
+    /// VirtualDatum itself.
     template<typename T_View, typename BoundDatumDomain, bool OwnView>
     struct VirtualDatum
     {
-        using View = T_View; ///< parent view of the virtual datum
-        using Mapping =
-            typename View::Mapping; ///< mapping of the underlying view
-        using UserDomain = typename Mapping::UserDomain;
-        using DatumDomain = typename Mapping::DatumDomain;
+        using View = T_View; ///< View this virtual datum points into.
 
-        const UserDomain
-            userDomainPos; ///< resolved position in the user domain
+    private:
+        using UserDomain = typename View::Mapping::UserDomain;
+        using DatumDomain = typename View::Mapping::DatumDomain;
+
+        const UserDomain userDomainPos;
         std::conditional_t<OwnView, View, View &> view;
 
-        /** Sub part of the datum domain of the view/mapping relative to
-         *  \ref BoundDatumDomain. If BoundDatumDomain is `DatumCoord<>`
-         * (default) AccessibleDatumDomain is the same as
-         * `Mapping::DatumDomain`.
-         */
+    public:
+        /// Subtree of the datum domain of View starting at \ref
+        /// BoundDatumDomain. If BoundDatumDomain is `DatumCoord<>` (default)
+        /// AccessibleDatumDomain is the same as `Mapping::DatumDomain`.
         using AccessibleDatumDomain = GetType<DatumDomain, BoundDatumDomain>;
 
         LLAMA_FN_HOST_ACC_INLINE
@@ -528,22 +379,16 @@ namespace llama
 
         VirtualDatum(const VirtualDatum &) = default;
         VirtualDatum(VirtualDatum &&) = default;
-        // VirtualDatum & operator=(const VirtualDatum &) = delete;
-        // VirtualDatum & operator=(VirtualDatum &&) = delete;
 
-        /** Explicit access function for a coordinate in the datum domain given
-         * as tree position indexes. If the address -- independently whether
-         * given as datum coord or UID -- is not a leaf but, a new virtual datum
-         * with a bound datum coord is returned. \tparam Coord... variadic
-         * number std::size_t numbers as tree coordinates \return reference to
-         * element at resolved user domain and given datum domain coordinate or
-         * a new virtual datum with a bound datum coord
-         */
+        /// Access a datum in the datum domain underneath the current virtual
+        /// datum using a \ref DatumCoord. If the access resolves to a leaf, a
+        /// reference to a variable inside the \ref View storage is returned,
+        /// otherwise another virtual datum.
         template<std::size_t... Coord>
         LLAMA_FN_HOST_ACC_INLINE auto access(DatumCoord<Coord...> = {}) const
             -> decltype(auto)
         {
-            if constexpr(IsDatumStruct<GetType<
+            if constexpr(isDatumStruct<GetType<
                              DatumDomain,
                              Cat<BoundDatumDomain, DatumCoord<Coord...>>>>)
             {
@@ -566,7 +411,7 @@ namespace llama
         LLAMA_FN_HOST_ACC_INLINE auto access(DatumCoord<Coord...> coord = {})
             -> decltype(auto)
         {
-            if constexpr(IsDatumStruct<GetType<
+            if constexpr(isDatumStruct<GetType<
                              DatumDomain,
                              Cat<BoundDatumDomain, DatumCoord<Coord...>>>>)
             {
@@ -584,35 +429,30 @@ namespace llama
             }
         }
 
-        /** Explicit access function for a coordinate in the datum domain given
-         * as unique identifier or \ref DatumCoord. If the address --
-         * independently whether given as datum coord or UID -- is not a leaf
-         * but, a new virtual datum with a bound datum coord is returned.
-         * \tparam UIDs... variadic number of types as unique
-         *  identifier
-         * \return reference to element at resolved user domain and given datum
-         *  domain coordinate or a new virtual datum with a bound datum coord
-         */
-        template<typename... UIDs>
-        LLAMA_FN_HOST_ACC_INLINE auto access(UIDs...) const -> decltype(auto)
+        /// Access a datum in the datum domain underneath the current virtual
+        /// datum using a series of tags. If the access resolves to a leaf, a
+        /// reference to a variable inside the \ref View storage is returned,
+        /// otherwise another virtual datum.
+        template<typename... Tags>
+        LLAMA_FN_HOST_ACC_INLINE auto access(Tags...) const -> decltype(auto)
         {
-            using DatumCoord = GetCoordFromUIDRelative<
+            using DatumCoord = GetCoordFromTagsRelative<
                 DatumDomain,
                 BoundDatumDomain,
-                UIDs...>;
+                Tags...>;
 
             LLAMA_FORCE_INLINE_RECURSIVE
             return access(DatumCoord{});
         }
 
         // FIXME(bgruber): remove redundancy
-        template<typename... UIDs>
-        LLAMA_FN_HOST_ACC_INLINE auto access(UIDs... uids) -> decltype(auto)
+        template<typename... Tags>
+        LLAMA_FN_HOST_ACC_INLINE auto access(Tags... uids) -> decltype(auto)
         {
-            using DatumCoord = GetCoordFromUIDRelative<
+            using DatumCoord = GetCoordFromTagsRelative<
                 DatumDomain,
                 BoundDatumDomain,
-                UIDs...>;
+                Tags...>;
 
             LLAMA_FORCE_INLINE_RECURSIVE
             return access(DatumCoord{});
@@ -632,16 +472,7 @@ namespace llama
             return access(DatumCoordOrUIDs{}...);
         }
 
-        /** operator overload() for a coordinate in the datum domain given as
-         *  unique identifier or \ref DatumCoord. If the address --
-         * independently whether given as datum coord or UID -- is not a leaf
-         * but, a new virtual datum with a bound datum coord is returned. \param
-         * unnamed instantiation of variadic number of unique
-         *  identifier types **or** \ref DatumCoord with tree coordinates as
-         *  template parameters inside
-         * \return reference to element at resolved user domain and given datum
-         *  domain coordinate or a new virtual datum with a bound datum coord
-         */
+        /// Calls \ref access with the passed arguments and returns the result.
         template<typename... DatumCoordOrUIDs>
         LLAMA_FN_HOST_ACC_INLINE auto operator()(DatumCoordOrUIDs...) const
             -> decltype(auto)
@@ -658,12 +489,56 @@ namespace llama
             return access(DatumCoordOrUIDs{}...);
         }
 
-        __LLAMA_VIRTUALDATUM_OPERATOR(=, Assignment)
-        __LLAMA_VIRTUALDATUM_OPERATOR(+=, Addition)
-        __LLAMA_VIRTUALDATUM_OPERATOR(-=, Subtraction)
-        __LLAMA_VIRTUALDATUM_OPERATOR(*=, Multiplication)
-        __LLAMA_VIRTUALDATUM_OPERATOR(/=, Division)
-        __LLAMA_VIRTUALDATUM_OPERATOR(%=, Modulo)
+#define __LLAMA_VIRTUALDATUM_OPERATOR(OP, FUNCTOR) \
+    template< \
+        typename OtherView, \
+        typename OtherBoundDatumDomain, \
+        bool OtherOwnView> \
+    LLAMA_FN_HOST_ACC_INLINE auto operator OP( \
+        const VirtualDatum<OtherView, OtherBoundDatumDomain, OtherOwnView> & \
+            other) \
+        ->VirtualDatum & \
+    { \
+        internal::GenericFunctor< \
+            std::remove_reference_t<decltype(*this)>, \
+            VirtualDatum<OtherView, OtherBoundDatumDomain, OtherOwnView>, \
+            DatumCoord<>, \
+            FUNCTOR> \
+            functor{*this, other}; \
+        forEach<AccessibleDatumDomain>(functor); \
+        return *this; \
+    } \
+\
+    template<typename OtherMapping, typename OtherBlobType> \
+    LLAMA_FN_HOST_ACC_INLINE auto operator OP( \
+        const llama::View<OtherMapping, OtherBlobType> & other) \
+        ->VirtualDatum & \
+    { \
+        return *this OP other( \
+            llama::UserDomain<OtherMapping::UserDomain::rank>{}); \
+    } \
+\
+    template< \
+        typename OtherType, \
+        typename \
+        = std::enable_if_t<!IsView<OtherType> && !is_VirtualDatum<OtherType>>> \
+    LLAMA_FN_HOST_ACC_INLINE auto operator OP(const OtherType & other) \
+        ->VirtualDatum & \
+    { \
+        internal::GenericTypeFunctor<decltype(*this), OtherType, FUNCTOR> \
+            functor{*this, other}; \
+        forEach<AccessibleDatumDomain>(functor); \
+        return *this; \
+    }
+
+        __LLAMA_VIRTUALDATUM_OPERATOR(=, internal::Assign)
+        __LLAMA_VIRTUALDATUM_OPERATOR(+=, internal::PlusAssign)
+        __LLAMA_VIRTUALDATUM_OPERATOR(-=, internal::MinusAssign)
+        __LLAMA_VIRTUALDATUM_OPERATOR(*=, internal::MultiplyAssign)
+        __LLAMA_VIRTUALDATUM_OPERATOR(/=, internal::DivideAssign)
+        __LLAMA_VIRTUALDATUM_OPERATOR(%=, internal::ModuloAssign)
+
+#undef __LLAMA_VIRTUALDATUM_OPERATOR
 
         // we need this one to disable the compiler generated copy assignment
         LLAMA_FN_HOST_ACC_INLINE auto operator=(const VirtualDatum & other)
@@ -675,32 +550,69 @@ namespace llama
         template<typename OtherType>
         LLAMA_FN_HOST_ACC_INLINE auto operator+(const OtherType & other)
         {
-            return stackVirtualDatumCopy(*this) += other;
+            return copyVirtualDatumStack(*this) += other;
         }
 
         template<typename OtherType>
         LLAMA_FN_HOST_ACC_INLINE auto operator-(const OtherType & other)
         {
-            return stackVirtualDatumCopy(*this) -= other;
+            return copyVirtualDatumStack(*this) -= other;
         }
 
         template<typename OtherType>
         LLAMA_FN_HOST_ACC_INLINE auto operator*(const OtherType & other)
         {
-            return stackVirtualDatumCopy(*this) *= other;
+            return copyVirtualDatumStack(*this) *= other;
         }
 
         template<typename OtherType>
         LLAMA_FN_HOST_ACC_INLINE auto operator/(const OtherType & other)
         {
-            return stackVirtualDatumCopy(*this) /= other;
+            return copyVirtualDatumStack(*this) /= other;
         }
 
         template<typename OtherType>
         LLAMA_FN_HOST_ACC_INLINE auto operator%(const OtherType & other)
         {
-            return stackVirtualDatumCopy(*this) %= other;
+            return copyVirtualDatumStack(*this) %= other;
         }
+
+#define __LLAMA_VIRTUALDATUM_BOOL_OPERATOR(OP, FUNCTOR) \
+    template< \
+        typename OtherView, \
+        typename OtherBoundDatumDomain, \
+        bool OtherOwnView> \
+    LLAMA_FN_HOST_ACC_INLINE auto operator OP( \
+        const VirtualDatum<OtherView, OtherBoundDatumDomain, OtherOwnView> & \
+            other) const->bool \
+    { \
+        internal::GenericBoolFunctor< \
+            std::remove_reference_t<decltype(*this)>, \
+            VirtualDatum<OtherView, OtherBoundDatumDomain, OtherOwnView>, \
+            DatumCoord<>, \
+            FUNCTOR> \
+            functor{*this, other, true}; \
+        forEach<AccessibleDatumDomain>(functor); \
+        return functor.result; \
+    } \
+\
+    template<typename OtherMapping, typename OtherBlobType> \
+    LLAMA_FN_HOST_ACC_INLINE auto operator OP( \
+        const llama::View<OtherMapping, OtherBlobType> & other) const->bool \
+    { \
+        return *this OP other( \
+            llama::UserDomain<OtherMapping::UserDomain::rank>{}); \
+    } \
+\
+    template<typename OtherType> \
+    LLAMA_FN_HOST_ACC_INLINE auto operator OP(const OtherType & other) \
+        const->bool \
+    { \
+        internal::GenericBoolTypeFunctor<decltype(*this), OtherType, FUNCTOR> \
+            functor{*this, other, true}; \
+        forEach<AccessibleDatumDomain>(functor); \
+        return functor.result; \
+    }
 
         __LLAMA_VIRTUALDATUM_BOOL_OPERATOR(==, std::equal_to<>)
         __LLAMA_VIRTUALDATUM_BOOL_OPERATOR(!=, std::not_equal_to<>)
@@ -708,18 +620,21 @@ namespace llama
         __LLAMA_VIRTUALDATUM_BOOL_OPERATOR(<=, std::less_equal<>)
         __LLAMA_VIRTUALDATUM_BOOL_OPERATOR(>, std::greater<>)
         __LLAMA_VIRTUALDATUM_BOOL_OPERATOR(>=, std::greater_equal<>)
+
+#undef __LLAMA_VIRTUALDATUM_BOOL_OPERATOR
     };
 
-    /** Central LLAMA class holding memory and giving access to it defined by a
-     *  mapping. Should not be instantiated "by hand" but with a \ref Factory.
-     * \tparam T_Mapping the mapping of the view
-     * \tparam T_BlobType the background data type of the raw data, at the
-     * moment always an 8 bit type like "unsigned char"
-     */
+    /// Central LLAMA class holding memory for storage and giving access to
+    /// values stored there defined by a mapping. A view should be created using
+    /// \ref allocView.
+    /// \tparam T_Mapping The mapping used by the view to map accesses into
+    /// memory.
+    /// \tparam BlobType The storage type used by the view holding
+    /// memory.
     template<typename T_Mapping, typename BlobType>
     struct View
     {
-        using Mapping = T_Mapping; ///< used mapping
+        using Mapping = T_Mapping;
         using UserDomain = typename Mapping::UserDomain;
         using DatumDomain = typename Mapping::DatumDomain;
         using VirtualDatumType = VirtualDatum<View<Mapping, BlobType>>;
@@ -727,23 +642,16 @@ namespace llama
             = VirtualDatum<const View<Mapping, BlobType>>;
 
         View() = default;
-        // View(View &&) noexcept = default;
-        // auto operator=(View &&) noexcept -> View & = default;
 
         LLAMA_NO_HOST_ACC_WARNING
         LLAMA_FN_HOST_ACC_INLINE
-        View(Mapping mapping, Array<BlobType, Mapping::blobCount> blob) :
-                mapping(mapping), blob(blob)
+        View(
+            Mapping mapping,
+            Array<BlobType, Mapping::blobCount> storageBlobs) :
+                mapping(mapping), storageBlobs(storageBlobs)
         {}
 
-        /** Operator overloading to reverse the order of compile time (datum
-         * domain) and run time (user domain) parameter with a helper object
-         *  (\ref llama::VirtualDatum). Should be favoured to access data
-         * because of the more array of struct like interface and the handy
-         * intermediate \ref llama::VirtualDatum object. \param userDomain user
-         * domain as \ref UserDomain \return \ref llama::VirtualDatum with bound
-         * user domain, which can be used to access the datum domain
-         */
+        /// Retrieves the \VirtualDatum at the given \ref UserDomain coordinate.
         LLAMA_FN_HOST_ACC_INLINE auto operator()(UserDomain userDomain) const
             -> VirtualDatumTypeConst
         {
@@ -758,61 +666,26 @@ namespace llama
             return {userDomain, *this};
         }
 
-        /** Operator overloading to reverse the order of compile time (datum
-         * domain) and run time (user domain) parameter with a helper object
-         *  (\ref llama::VirtualDatum). Should be favoured to access data
-         * because of the more array of struct like interface and the handy
-         * intermediate \ref llama::VirtualDatum object. \tparam Coord...
-         * types of user domain coordinates \param coord user domain as list of
-         * numbers \return \ref llama::VirtualDatum with bound user domain,
-         * which can be used to access the datum domain
-         */
-        template<typename... Coord>
-        LLAMA_FN_HOST_ACC_INLINE auto operator()(Coord... coord) const
+        /// Retrieves the \VirtualDatum at the \ref UserDomain coordinate
+        /// constructed from the passed component indices.
+        template<typename... Index>
+        LLAMA_FN_HOST_ACC_INLINE auto operator()(Index... indices) const
             -> VirtualDatumTypeConst
         {
             LLAMA_FORCE_INLINE_RECURSIVE
-            return {UserDomain{coord...}, *this};
+            return {UserDomain{indices...}, *this};
         }
 
-        template<typename... Coord>
-        LLAMA_FN_HOST_ACC_INLINE auto operator()(Coord... coord)
+        template<typename... Index>
+        LLAMA_FN_HOST_ACC_INLINE auto operator()(Index... indices)
             -> VirtualDatumType
         {
             LLAMA_FORCE_INLINE_RECURSIVE
-            return {UserDomain{coord...}, *this};
+            return {UserDomain{indices...}, *this};
         }
 
-        LLAMA_FN_HOST_ACC_INLINE auto operator()(std::size_t coord = 0) const
-            -> VirtualDatumTypeConst
-        {
-            LLAMA_FORCE_INLINE_RECURSIVE
-            return {UserDomain{coord}, *this};
-        }
-
-        LLAMA_FN_HOST_ACC_INLINE auto operator()(std::size_t coord = 0)
-            -> VirtualDatumType
-        {
-            LLAMA_FORCE_INLINE_RECURSIVE
-            return {UserDomain{coord}, *this};
-        }
-
-        template<std::size_t... Coord>
-        LLAMA_FN_HOST_ACC_INLINE auto
-        operator()(DatumCoord<Coord...> dc = {}) const -> decltype(auto)
-        {
-            LLAMA_FORCE_INLINE_RECURSIVE
-            return accessor<Coord...>(UserDomain{});
-        }
-
-        template<std::size_t... Coord>
-        LLAMA_FN_HOST_ACC_INLINE auto operator()(DatumCoord<Coord...> dc = {})
-            -> decltype(auto)
-        {
-            LLAMA_FORCE_INLINE_RECURSIVE
-            return accessor<Coord...>(UserDomain{});
-        }
-
+        /// Retrieves the \VirtualDatum at the \ref UserDomain coordinate
+        /// constructed from the passed component indices.
         LLAMA_FN_HOST_ACC_INLINE auto operator[](UserDomain userDomain) const
             -> VirtualDatumTypeConst
         {
@@ -827,22 +700,24 @@ namespace llama
             return (*this)(userDomain);
         }
 
-        LLAMA_FN_HOST_ACC_INLINE auto operator[](std::size_t coord) const
+        /// Retrieves the \VirtualDatum at the 1D \ref UserDomain coordinate
+        /// constructed from the passed index.
+        LLAMA_FN_HOST_ACC_INLINE auto operator[](std::size_t index) const
             -> VirtualDatumTypeConst
         {
             LLAMA_FORCE_INLINE_RECURSIVE
-            return (*this)(coord);
+            return (*this)(index);
         }
 
-        LLAMA_FN_HOST_ACC_INLINE auto operator[](std::size_t coord)
+        LLAMA_FN_HOST_ACC_INLINE auto operator[](std::size_t index)
             -> VirtualDatumType
         {
             LLAMA_FORCE_INLINE_RECURSIVE
-            return (*this)(coord);
+            return (*this)(index);
         }
 
-        Mapping mapping; ///< mapping of the view
-        Array<BlobType, Mapping::blobCount> blob; ///< memory of the view
+        Mapping mapping;
+        Array<BlobType, Mapping::blobCount> storageBlobs;
 
     private:
         template<typename T_View, typename T_BoundDatumDomain, bool OwnView>
@@ -857,7 +732,7 @@ namespace llama
             const auto [nr, offset]
                 = mapping.template getBlobNrAndOffset<Coords...>(userDomain);
             using Type = GetType<DatumDomain, DatumCoord<Coords...>>;
-            return reinterpret_cast<const Type &>(blob[nr][offset]);
+            return reinterpret_cast<const Type &>(storageBlobs[nr][offset]);
         }
 
         LLAMA_NO_HOST_ACC_WARNING
@@ -869,152 +744,81 @@ namespace llama
             const auto [nr, offset]
                 = mapping.template getBlobNrAndOffset<Coords...>(userDomain);
             using Type = GetType<DatumDomain, DatumCoord<Coords...>>;
-            return reinterpret_cast<Type &>(blob[nr][offset]);
+            return reinterpret_cast<Type &>(storageBlobs[nr][offset]);
         }
     };
 
-    /** Struct which acts like a \ref View, but shows only a smaller and/or
-     * shifted part of a parental (virtual) view. A virtual view does not hold
-     * any memory itself but has a reference to the parent view (and its
-     * memory). \tparam T_ParentViewType type of the parent, can also be another
-     * VirtualView
-     */
+    /// Acts like a \ref View, but shows only a smaller and/or shifted part of
+    /// another view it references, the parent view.
     template<typename T_ParentViewType>
     struct VirtualView
     {
-        using ParentView = T_ParentViewType; ///< type of parent view
-        using Mapping = typename ParentView::Mapping; ///< mapping type, gotten
-                                                      ///< from parent view
-        using UserDomain = typename Mapping::UserDomain;
+        using ParentView = T_ParentViewType; ///< type of the parent view
+        using Mapping =
+            typename ParentView::Mapping; ///< mapping of the parent view
+        using UserDomain =
+            typename Mapping::UserDomain; ///< user domain of the parent view
         using VirtualDatumType =
-            typename ParentView::VirtualDatumType; ///< VirtualDatum type,
-                                                   ///< gotten from parent view
+            typename ParentView::VirtualDatumType; ///< VirtualDatum type of the
+                                                   ///< parent view
 
-        /** Unlike a \ref View, a VirtualView can be created without a factory
-         *  directly from a parent view.
-         * \param parentView a reference to the parental view. Meaning, the
-         * parental view should not get out of scope before the virtual view.
-         * \param position shifted position relative to the parental view
-         * \param size size of the virtual view
-         */
+        /// Creates a VirtualView given a parent \ref View, offset and size.
         LLAMA_NO_HOST_ACC_WARNING
         LLAMA_FN_HOST_ACC_INLINE
         VirtualView(
             ParentView & parentView,
-            UserDomain position,
+            UserDomain offset,
             UserDomain size) :
-                parentView(parentView), position(position), size(size)
+                parentView(parentView), offset(offset), size(size)
         {}
 
-        /** Explicit access function taking the datum domain as tree index
-         *  coordinate template arguments and the user domain as runtime
-         * parameter. The operator() overloadings should be preferred as they
-         * show a more array of struct like interface using \ref VirtualDatum.
-         * \tparam Coords... tree index coordinate
-         * \param userDomain user domain as \ref UserDomain
-         * \return reference to element
-         */
         LLAMA_NO_HOST_ACC_WARNING
         template<std::size_t... Coords>
         LLAMA_FN_HOST_ACC_INLINE auto accessor(UserDomain userDomain) const
             -> const auto &
         {
-            return parentView.template accessor<Coords...>(
-                userDomain + position);
+            return parentView.template accessor<Coords...>(userDomain + offset);
         }
 
         LLAMA_NO_HOST_ACC_WARNING
         template<std::size_t... Coords>
         LLAMA_FN_HOST_ACC_INLINE auto accessor(UserDomain userDomain) -> auto &
         {
-            return parentView.template accessor<Coords...>(
-                userDomain + position);
+            return parentView.template accessor<Coords...>(userDomain + offset);
         }
 
-        /** Explicit access function taking the datum domain as UID type list
-         *  template arguments and the user domain as runtime parameter.
-         *  The operator() overloadings should be preferred as they show a more
-         *  array of struct like interface using \ref VirtualDatum.
-         * \tparam UIDs... UID type list
-         * \param userDomain user domain as \ref UserDomain
-         * \return reference to element
-         */
-        LLAMA_NO_HOST_ACC_WARNING
-        template<typename... UIDs>
-        LLAMA_FN_HOST_ACC_INLINE auto accessor(UserDomain userDomain) const
-            -> const auto &
-        {
-            return parentView.template accessor<UIDs...>(userDomain + position);
-        }
-
-        LLAMA_NO_HOST_ACC_WARNING
-        template<typename... UIDs>
-        LLAMA_FN_HOST_ACC_INLINE auto accessor(UserDomain userDomain) -> auto &
-        {
-            return parentView.template accessor<UIDs...>(userDomain + position);
-        }
-
-        /** Operator overloading to reverse the order of compile time (datum
-         * domain) and run time (user domain) parameter with a helper object
-         *  (\ref VirtualDatum). Should be favoured to access data because of
-         * the more array of struct like interface and the handy intermediate
-         *  \ref VirtualDatum object.
-         * \param userDomain user domain as \ref UserDomain
-         * \return \ref VirtualDatum with bound user domain, which can be used
-         * to access the datum domain
-         */
+        /// Same as \ref View::operator(), but shifted by the offset of this
+        /// \ref VirtualView.
         LLAMA_FN_HOST_ACC_INLINE auto operator()(UserDomain userDomain) const
             -> VirtualDatumType
         {
             LLAMA_FORCE_INLINE_RECURSIVE
-            return parentView(userDomain + position);
+            return parentView(userDomain + offset);
         }
 
         LLAMA_FN_HOST_ACC_INLINE auto operator()(UserDomain userDomain)
             -> VirtualDatumType
         {
             LLAMA_FORCE_INLINE_RECURSIVE
-            return parentView(userDomain + position);
+            return parentView(userDomain + offset);
         }
 
-        /** Operator overloading to reverse the order of compile time (datum
-         * domain) and run time (user domain) parameter with a helper object
-         *  (\ref VirtualDatum). Should be favoured to access data because of
-         * the more array of struct like interface and the handy intermediate
-         *  \ref VirtualDatum object.
-         * \tparam Coord... types of user domain coordinates
-         * \param coord user domain as list of numbers
-         * \return \ref VirtualDatum with bound user domain, which can be used
-         * to access the datum domain
-         */
-        template<typename... Coord>
-        LLAMA_FN_HOST_ACC_INLINE auto operator()(Coord... coord) const
+        /// Same as \ref View::operator(), but shifted by the offset of this
+        /// \ref VirtualView.
+        template<typename... Indices>
+        LLAMA_FN_HOST_ACC_INLINE auto operator()(Indices... indices) const
             -> VirtualDatumType
         {
             LLAMA_FORCE_INLINE_RECURSIVE
-            return parentView(UserDomain{coord...} + position);
+            return parentView(UserDomain{indices...} + offset);
         }
 
-        template<typename... Coord>
-        LLAMA_FN_HOST_ACC_INLINE auto operator()(Coord... coord)
+        template<typename... Indices>
+        LLAMA_FN_HOST_ACC_INLINE auto operator()(Indices... indices)
             -> VirtualDatumType
         {
             LLAMA_FORCE_INLINE_RECURSIVE
-            return parentView(UserDomain{coord...} + position);
-        }
-
-        LLAMA_FN_HOST_ACC_INLINE
-        auto operator()(std::size_t coord = 0) const -> VirtualDatumType
-        {
-            LLAMA_FORCE_INLINE_RECURSIVE
-            return parentView(UserDomain{coord} + position);
-        }
-
-        LLAMA_FN_HOST_ACC_INLINE
-        auto operator()(std::size_t coord = 0) -> VirtualDatumType
-        {
-            LLAMA_FORCE_INLINE_RECURSIVE
-            return parentView(UserDomain{coord} + position);
+            return parentView(UserDomain{indices...} + offset);
         }
 
         template<std::size_t... Coord>
@@ -1033,8 +837,10 @@ namespace llama
             return accessor<Coord...>(UserDomain{});
         }
 
-        ParentView & parentView; ///< reference to parental view
-        const UserDomain position; ///< shifted position in parental view
-        const UserDomain size; ///< shown size
+        ParentView & parentView; ///< reference to parent view.
+        const UserDomain
+            offset; ///< offset this view's \ref UserDomain coordinates are
+                    ///< shifted to the parent view.
+        const UserDomain size;
     };
-} // namespace llama
+}

--- a/include/llama/llama.hpp
+++ b/include/llama/llama.hpp
@@ -29,11 +29,11 @@
  *
  * In contrast to many other solutions LLAMA can define nested data structures
  * of arbitrary depths and is not limited only to struct of array and array of
- * struct data layouts but is also capable to explicitly define padding,
+ * struct data layouts. It is also capable to explicitly define padding,
  * blocking, striding and any other run time or compile time access pattern
  * simultaneously.
  *
- * To archieve this goal LLAMA is splitted in mostly independent, orthogonal
+ * To archieve this goal LLAMA is split into mostly independent, orthogonal
  * parts completely written in modern C++17 to run on as many architectures and
  * with as many compilers as possible while still supporting extensions needed
  * e.g. to run on GPU or other many core hardware.

--- a/include/llama/llama.hpp
+++ b/include/llama/llama.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/macros.hpp
+++ b/include/llama/macros.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/macros.hpp
+++ b/include/llama/macros.hpp
@@ -45,39 +45,19 @@
 #elif defined(_MSC_VER)
 #define LLAMA_INDEPENDENT_DATA __pragma(loop(ivdep))
 #else
-/** Shows that all (!) data access inside inside of a loop is indepent, so the
- *  loop can safely be vectorized although the compiler may not know the data
- *  dependencies completely. Usage looks like this
- * \code{.cpp}
- *  LLAMA_INDEPENDENT_DATA
- *  for (int i = 0; i < N; ++i)
- *      // because of LLAMA_INDEPENDENT_DATA the compiler knows that a and b do
- *      // not overlap and the operation can safely be vectorized
- *      a[i] += b[i];
- * \endcode
- */
+/// May be put in front of a loop statement. Indicates that all (!) data access
+/// inside the loop is indepent, so the loop can be safely vectorized. Example:
+/// \code{.cpp}
+///     LLAMA_INDEPENDENT_DATA
+///     for(int i = 0; i < N; ++i)
+///         // because of LLAMA_INDEPENDENT_DATA the compiler knows that a and b
+///         // do not overlap and the operation can safely be vectorized
+///         a[i] += b[i];
+/// \endcode
 #define LLAMA_INDEPENDENT_DATA
 #endif
 
 #ifndef LLAMA_FN_HOST_ACC_INLINE
-/** Some offloading parallelization language extensions such a CUDA, OpenACC or
- *  OpenMP 4.5 need to specify whether a class, struct, function or method
- *  "resides" on the host, the accelerator (the offloading device) or both.
- *  LLAMA supports this with marking every function wich would be needed on an
- *  accelerator with `LLAMA_FN_HOST_ACC_INLINE`. When using such a language (or
- *  e.g.
- *  <a href="https://github.com/ComputationalRadiationPhysics/alpaka">alpaka</a>
- *  ) the define can be redefined before including LLAMA, e.g. for alpaka:
- * \code{.cpp}
- *  #include <alpaka/alpaka.hpp>
- *  #ifdef __CUDACC__
- *      #define LLAMA_FN_HOST_ACC_INLINE ALPAKA_FN_ACC __forceinline__
- *  #else
- *      #define LLAMA_FN_HOST_ACC_INLINE ALPAKA_FN_ACC inline
- *  #endif
- *  #include <llama/llama.hpp>
- * \endcode
- */
 #if BOOST_COMP_NVCC != 0
 #define LLAMA_FN_HOST_ACC_INLINE __forceinline__
 #elif BOOST_COMP_GNUC != 0
@@ -85,6 +65,14 @@
 #elif defined(_MSC_VER)
 #define LLAMA_FN_HOST_ACC_INLINE __forceinline
 #else
+/// Some offloading parallelization language extensions such a CUDA, OpenACC or
+/// OpenMP 4.5 need to specify whether a class, struct, function or method
+/// "resides" on the host, the accelerator (the offloading device) or both.
+/// LLAMA supports this with marking every function needed on an accelerator
+/// with `LLAMA_FN_HOST_ACC_INLINE`. When using such a language (or e.g. <a
+/// href="https://github.com/ComputationalRadiationPhysics/alpaka">alpaka</a>)
+/// this macro should be defined on the compiler's command line. E.g. for
+/// alpaka: -D'LLAMA_FN_HOST_ACC_INLINE=ALPAKA_FN_HOST_ACC'
 #define LLAMA_FN_HOST_ACC_INLINE inline
 #endif
 #endif
@@ -109,15 +97,9 @@
 #elif defined(_MSC_VER)
 #define LLAMA_FORCE_INLINE_RECURSIVE __pragma(inline_depth(255))
 #else
-/** If possible forces the compiler to recursively inline the following function
- *  and all child function calls. Should be use carefully as at least the
- *  Intel compiler implementation seems to be buggy.
- */
+/// Forces the compiler to recursively inline the call hiearchy started by the
+/// subsequent function call.
 #define LLAMA_FORCE_INLINE_RECURSIVE
 #endif
 
 #define LLAMA_DEREFERENCE(x) decltype(x)(x)
-
-#ifndef LLAMA_IGNORE_LITERAL
-#define LLAMA_IGNORE_LITERAL(x)
-#endif

--- a/include/llama/mapping/AoS.hpp
+++ b/include/llama/mapping/AoS.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/AoS.hpp
+++ b/include/llama/mapping/AoS.hpp
@@ -23,20 +23,11 @@
 
 namespace llama::mapping
 {
-    /** Array of struct mapping which can be used for creating a \ref View with
-     * a \ref Factory. For the interface details see \ref Factory. \tparam
-     * T_UserDomain type of the user domain \tparam T_DatumDomain type of the
-     * datum domain \tparam LinearizeUserDomainAdressFunctor Defines how the
-     * user domain should be linearized, e.g. C like with the last dimension
-     * being the "fast" one
-     *  (\ref LinearizeUserDomainAdress, default) or Fortran like with the first
-     *  dimension being the "fast" one (\ref
-     * LinearizeUserDomainAdressLikeFortran). \tparam
-     * ExtentUserDomainAdressFunctor Defines how the size of the view shall be
-     * created. Should fit for `T_LinearizeUserDomainAdressFunctor`. Only right
-     * now implemented and default value is \ref ExtentUserDomainAdress. \see
-     * SoA
-     */
+    /// Array of struct mapping. Used to create a \ref View via \ref allocView.
+    /// \tparam LinearizeUserDomainAdressFunctor Defines how the
+    /// user domain should be mapped into linear numbers.
+    /// \tparam ExtentUserDomainAdressFunctor Defines how the total number of
+    /// \ref UserDomain indices is calculated.
     template<
         typename T_UserDomain,
         typename T_DatumDomain,

--- a/include/llama/mapping/AoSoA.hpp
+++ b/include/llama/mapping/AoSoA.hpp
@@ -5,6 +5,14 @@
 
 namespace llama::mapping
 {
+    /// Array of struct of arrays mapping. Used to create a \ref View via \ref
+    /// allocView.
+    /// \tparam Lanes The size of the inner arrays of this array of struct of
+    /// arrays.
+    /// \tparam LinearizeUserDomainAdressFunctor Defines how the user
+    /// domain should be mapped into linear numbers.
+    /// \tparam ExtentUserDomainAdressFunctor Defines how the total number of
+    /// \ref UserDomain indices is calculated.
     template<
         typename T_UserDomain,
         typename T_DatumDomain,

--- a/include/llama/mapping/AoSoA.hpp
+++ b/include/llama/mapping/AoSoA.hpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #pragma once
 
 #include "../Types.hpp"

--- a/include/llama/mapping/Common.hpp
+++ b/include/llama/mapping/Common.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/Common.hpp
+++ b/include/llama/mapping/Common.hpp
@@ -24,7 +24,8 @@
 
 namespace llama
 {
-    /// Functor that calculates the extent of a user domain
+    /// Functor that calculates the extent of a user domain for use with \ref
+    /// LinearizeUserDomainAdress or \ref LinearizeUserDomainAdressLikeFortran.
     struct ExtentUserDomainAdress
     {
         template<std::size_t Dim>
@@ -37,11 +38,8 @@ namespace llama
         }
     };
 
-    /** Functor to get the linear position of a coordinate in the user domain
-     * space if the n-dimensional domain is flattened to one dimension with the
-     * last user domain index being the fastet resp. already linearized index (C
-     * like). \see LinearizeUserDomainAdressLikeFortran
-     * */
+    /// Functor that maps a \ref UserDomain coordinate into linear numbers the
+    /// way C++ arrays work.
     struct LinearizeUserDomainAdress
     {
         /**
@@ -64,12 +62,8 @@ namespace llama
         }
     };
 
-    /** Functor to get the linear position of a coordinate in the user domain
-     * space if the n-dimensional domain is flattened to one dimension with the
-     * first user domain index being the fastet resp. already linearized index
-     * (Fortran like). \tparam Dim dimension of the user domain \see
-     * LinearizeUserDomainAdress
-     * */
+    /// Functor that maps a \ref UserDomain coordinate into linear numbers the
+    /// way Fortran arrays work.
     struct LinearizeUserDomainAdressLikeFortran
     {
         /**
@@ -92,6 +86,8 @@ namespace llama
         }
     };
 
+    /// Functor that calculates the extent of a user domain for use with \ref
+    /// LinearizeUserDomainMorton.
     struct ExtentUserDomainMorton
     {
         template<std::size_t Dim>
@@ -127,6 +123,8 @@ namespace llama
         }
     };
 
+    /// Functor that maps a \ref UserDomain coordinate into linear numbers using
+    /// the Z-order space filling curve (Morton codes).
     struct LinearizeUserDomainMorton
     {
         template<std::size_t Dim>

--- a/include/llama/mapping/Dump.hpp
+++ b/include/llama/mapping/Dump.hpp
@@ -43,7 +43,7 @@ namespace llama::mapping
             DatumCoord<CoordsBefore...> before,
             DatumCoord<CoordCurrent, CoordsAfter...> after)
         {
-            using Tag = GetUID<
+            using Tag = GetTag<
                 DatumDomain,
                 DatumCoord<CoordsBefore..., CoordCurrent>>;
             v.push_back(tagToString(Tag{}));
@@ -74,6 +74,9 @@ namespace llama::mapping
         }
     }
 
+    /// Returns an SVG image visualizing the memory layout created by the given
+    /// mapping. The created memory blocks are wrapped after wrapByteCount
+    /// bytes.
     template<typename Mapping>
     auto toSvg(const Mapping & mapping, int wrapByteCount = 64) -> std::string
     {

--- a/include/llama/mapping/Dump.hpp
+++ b/include/llama/mapping/Dump.hpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #pragma once
 
 #include "../ForEach.hpp"

--- a/include/llama/mapping/Interface.hpp
+++ b/include/llama/mapping/Interface.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/One.hpp
+++ b/include/llama/mapping/One.hpp
@@ -23,15 +23,9 @@
 
 namespace llama::mapping
 {
-    /** Neither struct of array nor array of struct mapping as only exactly one
-     *  element (in the user domain) can be mapped. If more than one element is
-     *  tried to be mapped all virtual datums are mapped to the very same
-     * memory. This mapping is especially used for temporary views on the stack
-     * allocated with \ref stackViewAlloc. \tparam T_UserDomain type of the user
-     * domain, expected to have only element, although more are working (but
-     * doesn't make sense) \tparam T_DatumDomain type of the datum domain \see
-     * stackViewAlloc, OneOnStackFactory, allocator::Stack
-     */
+    /// Maps all UserDomain coordinates into the same location and layouts
+    /// struct members consecutively. This mapping is used for temporary, single
+    /// element views.
     template<typename T_UserDomain, typename T_DatumDomain>
     struct One
     {
@@ -47,11 +41,10 @@ namespace llama::mapping
         }
 
         template<std::size_t... DatumDomainCoord>
-        LLAMA_FN_HOST_ACC_INLINE auto getBlobNrAndOffset(UserDomain coord) const
+        LLAMA_FN_HOST_ACC_INLINE auto getBlobNrAndOffset(UserDomain) const
             -> NrAndOffset
         {
-            constexpr auto offset
-                = offsetOf<DatumDomain, DatumDomainCoord...>;
+            constexpr auto offset = offsetOf<DatumDomain, DatumDomainCoord...>;
             return {0, offset};
         }
     };

--- a/include/llama/mapping/One.hpp
+++ b/include/llama/mapping/One.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -24,20 +24,11 @@
 
 namespace llama::mapping
 {
-    /** Struct of array mapping which can be used for creating a \ref View with
-     * a \ref Factory. For the interface details see \ref Factory. \tparam
-     * T_UserDomain type of the user domain \tparam T_DatumDomain type of the
-     * datum domain \tparam LinearizeUserDomainAdressFunctor Defines how the
-     * user domain should be linearized, e.g. C like with the last dimension
-     * being the "fast" one
-     *  (\ref LinearizeUserDomainAdress, default) or Fortran like with the first
-     *  dimension being the "fast" one (\ref
-     * LinearizeUserDomainAdressLikeFortran). \tparam
-     * ExtentUserDomainAdressFunctor Defines how the size of the view shall be
-     * created. Should fit for `T_LinearizeUserDomainAdressFunctor`. Only right
-     * now implemented and default value is \ref ExtentUserDomainAdress. \see
-     * AoS
-     */
+    /// Struct of array mapping. Used to create a \ref View via \ref allocView.
+    /// \tparam LinearizeUserDomainAdressFunctor Defines how the
+    /// user domain should be mapped into linear numbers.
+    /// \tparam ExtentUserDomainAdressFunctor Defines how the total number of
+    /// \ref UserDomain indices is calculated.
     template<
         typename T_UserDomain,
         typename T_DatumDomain,

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/tree/Functors.hpp
+++ b/include/llama/mapping/tree/Functors.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/tree/Functors.hpp
+++ b/include/llama/mapping/tree/Functors.hpp
@@ -22,8 +22,8 @@
 
 namespace llama::mapping::tree::functor
 {
-    /// Functor for \ref tree::Mapping. Does nothing with the mapping tree at
-    /// all (basically implemented for testing purposes). \see tree::Mapping
+    /// Functor for \ref tree::Mapping. Does nothing with the mapping tree. Is
+    /// used for testing.
     struct Idem
     {
         template<typename Tree>
@@ -51,9 +51,7 @@ namespace llama::mapping::tree::functor
     };
 
     /// Functor for \ref tree::Mapping. Moves all run time parts to the leaves,
-    /// so in fact another struct of array implementation -- but with the
-    /// possibility to add further finetuning of the mapping in the future. \see
-    /// tree::Mapping
+    /// creating a SoA layout.
     struct LeafOnlyRT
     {
         template<typename Tree>
@@ -257,8 +255,9 @@ namespace llama::mapping::tree::functor
     }
 
     /// Functor for \ref tree::Mapping. Move the run time part of a node one
-    /// level down in direction of the leaves. \warning Broken at the moment
-    /// \tparam T_TreeCoord tree coordinate in the mapping tree which's run time
+    /// level down in direction of the leaves by the given amount (runtime or
+    /// compile time value).
+    /// \tparam TreeCoord tree coordinate in the mapping tree which's run time
     /// part shall be moved down one level \see tree::Mapping
     template<typename TreeCoord, typename Amount = std::size_t>
     struct MoveRTDown

--- a/include/llama/mapping/tree/Mapping.hpp
+++ b/include/llama/mapping/tree/Mapping.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/tree/Mapping.hpp
+++ b/include/llama/mapping/tree/Mapping.hpp
@@ -215,12 +215,11 @@ namespace llama::mapping::tree
         }
     }
 
-    /** Free describable mapping which can be used for creating a \ref View with
-     * a \ref Factory. For the interface details see \ref Factory. \tparam
-     * T_UserDomain type of the user domain \tparam T_DatumDomain type of the
-     * datum domain \tparam TreeOperationList (\ref Tuple) of operations to
-     * define the tree mapping
-     */
+    /// An experimental attempt to provide a general purpose description of a
+    /// mapping. \ref UserDomain and datum domain are represented by a compile
+    /// time tree data structure. This tree is mapped into memory by means of a
+    /// breadth-first tree traversal. By specifying additional tree operations,
+    /// the tree can be modified at compile time before being mapped to memory.
     template<
         typename T_UserDomain,
         typename T_DatumDomain,
@@ -245,14 +244,6 @@ namespace llama::mapping::tree
 
         Mapping() = default;
 
-        /** The initalization of this mapping needs a \ref Tuple of operations
-         *  which describe the mapping in detail. Please have a look at the user
-         *  documenation for more information.
-         * \param size the size of the user domain
-         * \param treeOperationList list of operations to define the mapping,
-         * e.g. \ref functor::Idem, \ref functor::LeafOnlyRT, \ref
-         * functor::MoveRTDown.
-         */
         LLAMA_FN_HOST_ACC_INLINE
         Mapping(UserDomain size, TreeOperationList treeOperationList) :
                 userDomainSize(size),

--- a/include/llama/mapping/tree/TreeFromDomains.hpp
+++ b/include/llama/mapping/tree/TreeFromDomains.hpp
@@ -113,7 +113,7 @@ namespace llama::mapping::tree
             using type = Node<
                 Tag,
                 Tuple<typename CreateTreeElement<
-                    GetDatumElementUID<DatumElements>,
+                    GetDatumElementTag<DatumElements>,
                     GetDatumElementType<DatumElements>,
                     boost::mp11::mp_size_t<1>>::type...>,
                 CountType>;
@@ -144,15 +144,15 @@ namespace llama::mapping::tree
     template<typename UserDomain, typename DatumDomain>
     using TreeFromDomains = typename internal::WrapInNNodes<
         internal::TreeFromDatumDomainImpl<DatumDomain>,
-        UserDomain::count - 1>::type;
+        UserDomain::rank - 1>::type;
 
     template<typename DatumDomain, typename UserDomain, std::size_t Pos = 0>
     LLAMA_FN_HOST_ACC_INLINE auto createTree(const UserDomain & size)
     {
-        if constexpr(Pos == UserDomain::count - 1)
+        if constexpr(Pos == UserDomain::rank - 1)
         {
             return TreeFromDatumDomain<DatumDomain>{
-                size[UserDomain::count - 1]};
+                size[UserDomain::rank - 1]};
         }
         else
         {
@@ -175,7 +175,7 @@ namespace llama::mapping::tree
         {
             return Tuple{
                 TreeCoordElement<(
-                    UDIndices == UserDomain::count - 1 ? FirstDatumDomainCoord
+                    UDIndices == UserDomain::rank - 1 ? FirstDatumDomainCoord
                                                        : 0)>(
                     coord[UDIndices])...,
                 TreeCoordElement<
@@ -189,6 +189,6 @@ namespace llama::mapping::tree
     LLAMA_FN_HOST_ACC_INLINE auto createTreeCoord(const UserDomain & coord)
     {
         return internal::createTreeCoord(
-            coord, std::make_index_sequence<UserDomain::count>{}, DatumCoord{});
+            coord, std::make_index_sequence<UserDomain::rank>{}, DatumCoord{});
     }
 }

--- a/include/llama/mapping/tree/TreeFromDomains.hpp
+++ b/include/llama/mapping/tree/TreeFromDomains.hpp
@@ -1,21 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
-
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once
 
 #include "../../Tuple.hpp"

--- a/include/llama/mapping/tree/toString.hpp
+++ b/include/llama/mapping/tree/toString.hpp
@@ -1,20 +1,5 @@
-/* Copyright 2018 Alexander Matthes
- *
- * This file is part of LLAMA.
- *
- * LLAMA is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * LLAMA is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with LLAMA.  If not, see <www.gnu.org/licenses/>.
- */
+// Copyright 2018 Alexander Matthes
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 

--- a/tests/common.h
+++ b/tests/common.h
@@ -66,13 +66,13 @@ template<typename View>
 void zeroStorage(View & view)
 {
     for(auto i = 0; i < View::Mapping::blobCount; i++)
-        internal::zeroBlob(view.blob[i], view.mapping.getBlobSize(i));
+        internal::zeroBlob(view.storageBlobs[i], view.mapping.getBlobSize(i));
 }
 
 template <typename View>
 void iotaStorage(View& view) {
     for (auto i = 0; i < View::Mapping::blobCount; i++) {
         auto fillFunc = [val = 0]() mutable { return static_cast<typename View::BlobType::PrimType>(val++); };
-        std::generate_n(view.blob[i].blob.get(), view.mapping.getBlobSize(i), fillFunc);
+        std::generate_n(view.storageBlobs[i].storageBlobs.get(), view.mapping.getBlobSize(i), fillFunc);
     }
 }

--- a/tests/treemap.cpp
+++ b/tests/treemap.cpp
@@ -1069,11 +1069,11 @@ TEST_CASE("treemapping")
         for(size_t y = 0; y < userDomain[1]; ++y)
         {
             auto datum = view(x, y);
-            llama::GenericFunctor<
+            llama::internal::GenericFunctor<
                 decltype(datum),
                 decltype(datum),
                 tag::Pos,
-                llama::Addition>
+                llama::internal::PlusAssign>
                 as{datum, datum};
             llama::forEach<Name>(as, tag::Momentum{});
             //~ auto datum2 = view( x+1, y );

--- a/tests/uid.cpp
+++ b/tests/uid.cpp
@@ -36,59 +36,59 @@ using Other = llama::DS<
 >;
 // clang-format on
 
-TEST_CASE("GetCoordFromUID")
+TEST_CASE("GetCoordFromTags")
 {
     // clang-format off
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromUID<Particle                             >, llama::DatumCoord<    >>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromUID<Particle, tag::Pos                   >, llama::DatumCoord<0   >>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromUID<Particle, tag::Pos, tag::X           >, llama::DatumCoord<0, 0>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromUID<Particle, tag::Pos, tag::Y           >, llama::DatumCoord<0, 1>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromUID<Particle, tag::Pos, tag::Z           >, llama::DatumCoord<0, 2>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromUID<Particle, llama::NoName              >, llama::DatumCoord<1   >>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromUID<Particle, tag::Vel, tag::Z           >, llama::DatumCoord<2, 0>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromUID<Particle, tag::Vel, tag::X           >, llama::DatumCoord<2, 1>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromUID<Particle, tag::Flags                 >, llama::DatumCoord<3   >>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromUID<Particle, tag::Flags, llama::Index<0>>, llama::DatumCoord<3, 0>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromUID<Particle, tag::Flags, llama::Index<1>>, llama::DatumCoord<3, 1>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromUID<Particle, tag::Flags, llama::Index<2>>, llama::DatumCoord<3, 2>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromUID<Particle, tag::Flags, llama::Index<3>>, llama::DatumCoord<3, 3>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle                             >, llama::DatumCoord<    >>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos                   >, llama::DatumCoord<0   >>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos, tag::X           >, llama::DatumCoord<0, 0>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos, tag::Y           >, llama::DatumCoord<0, 1>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos, tag::Z           >, llama::DatumCoord<0, 2>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, llama::NoName              >, llama::DatumCoord<1   >>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Vel, tag::Z           >, llama::DatumCoord<2, 0>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Vel, tag::X           >, llama::DatumCoord<2, 1>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags                 >, llama::DatumCoord<3   >>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::Index<0>>, llama::DatumCoord<3, 0>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::Index<1>>, llama::DatumCoord<3, 1>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::Index<2>>, llama::DatumCoord<3, 2>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::Index<3>>, llama::DatumCoord<3, 3>>);
     // clang-format on
 }
 
-TEST_CASE("GetUID")
+TEST_CASE("GetTag")
 {
     // clang-format off
-    STATIC_REQUIRE(std::is_same_v<llama::GetUID<Particle, llama::DatumCoord<0, 0>>, tag::X       >);
-    STATIC_REQUIRE(std::is_same_v<llama::GetUID<Particle, llama::DatumCoord<0   >>, tag::Pos     >);
-    STATIC_REQUIRE(std::is_same_v<llama::GetUID<Particle, llama::DatumCoord<    >>, llama::NoName>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetUID<Particle, llama::DatumCoord<2, 1>>, tag::X       >);
+    STATIC_REQUIRE(std::is_same_v<llama::GetTag<Particle, llama::DatumCoord<0, 0>>, tag::X       >);
+    STATIC_REQUIRE(std::is_same_v<llama::GetTag<Particle, llama::DatumCoord<0   >>, tag::Pos     >);
+    STATIC_REQUIRE(std::is_same_v<llama::GetTag<Particle, llama::DatumCoord<    >>, llama::NoName>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetTag<Particle, llama::DatumCoord<2, 1>>, tag::X       >);
     // clang-format on
 }
 
-TEST_CASE("CompareUID")
+TEST_CASE("hasSameTags")
 {
     STATIC_REQUIRE(
-        llama::CompareUID<
+        llama::hasSameTags<
             Particle, // DD A
-            llama::GetCoordFromUID<Particle, tag::Pos>, // Base A
+            llama::GetCoordFromTags<Particle, tag::Pos>, // Base A
             llama::DatumCoord<0>, // Local A
             Particle, // DD B
-            llama::GetCoordFromUID<Particle, tag::Vel>, // Base B
+            llama::GetCoordFromTags<Particle, tag::Vel>, // Base B
             llama::DatumCoord<0> // Local B
             > == false);
 
     STATIC_REQUIRE(
-        llama::CompareUID<
+        llama::hasSameTags<
             Particle, // DD A
-            llama::GetCoordFromUID<Particle, tag::Pos>, // Base A
+            llama::GetCoordFromTags<Particle, tag::Pos>, // Base A
             llama::DatumCoord<0>, // Local A
             Particle, // DD B
-            llama::GetCoordFromUID<Particle, tag::Vel>, // Base B
+            llama::GetCoordFromTags<Particle, tag::Vel>, // Base B
             llama::DatumCoord<1> // Local B
             > == true);
 
     STATIC_REQUIRE(
-        llama::CompareUID<
+        llama::hasSameTags<
             Particle, // DD A
             llama::DatumCoord<>, // Base A
             llama::DatumCoord<0, 0>, // Local A
@@ -98,7 +98,7 @@ TEST_CASE("CompareUID")
             > == false);
 
     STATIC_REQUIRE(
-        llama::CompareUID<
+        llama::hasSameTags<
             Particle, // DD A
             llama::DatumCoord<>, // Base A
             llama::DatumCoord<0, 2>, // Local A
@@ -108,7 +108,7 @@ TEST_CASE("CompareUID")
             > == true);
 
     STATIC_REQUIRE(
-        llama::CompareUID<
+        llama::hasSameTags<
             Particle, // DD A
             llama::DatumCoord<>, // Base A
             llama::DatumCoord<2, 0>, // Local A

--- a/tests/view.cpp
+++ b/tests/view.cpp
@@ -218,7 +218,7 @@ TEST_CASE("view.assign-one-datum")
     Mapping mapping{userDomain};
     auto view = allocView(mapping);
 
-    auto datum = llama::stackVirtualDatumAlloc<Particle>();
+    auto datum = llama::allocVirtualDatumStack<Particle>();
     datum(tag::Pos{}, tag::X{}) = 14.0f;
     datum(tag::Pos{}, tag::Y{}) = 15.0f;
     datum(tag::Pos{}, tag::Z{}) = 16.0f;

--- a/tests/virtualdatum.cpp
+++ b/tests/virtualdatum.cpp
@@ -29,7 +29,7 @@ using Name = llama::DS<
 
 TEST_CASE("VirtualDatum.operator=")
 {
-    auto datum = llama::stackVirtualDatumAlloc<Name>();
+    auto datum = llama::allocVirtualDatumStack<Name>();
 
     // scalar to multiple elements in virtual datum
     datum(tag::Pos{}) = 1;
@@ -82,7 +82,7 @@ TEST_CASE("VirtualDatum.operator=")
 
 TEST_CASE("VirtualDatum.operator+=")
 {
-    auto datum = llama::stackVirtualDatumAlloc<Name>();
+    auto datum = llama::allocVirtualDatumStack<Name>();
 
     // scalar to multiple elements in virtual datum
     datum(tag::Pos{}) += 1;
@@ -132,7 +132,7 @@ TEST_CASE("VirtualDatum.operator+=")
 
 TEST_CASE("VirtualDatum.operator+")
 {
-    auto datum = llama::stackVirtualDatumAlloc<Name>();
+    auto datum = llama::allocVirtualDatumStack<Name>();
 
     // scalar to multiple elements in virtual datum
     datum(tag::Pos{}) = datum(tag::Pos{}) + 1;
@@ -204,7 +204,7 @@ using Name2 = llama::DS<
 
 TEST_CASE("VirtualDatum.operator=.propagation")
 {
-    auto datum = llama::stackVirtualDatumAlloc<Name2>();
+    auto datum = llama::allocVirtualDatumStack<Name2>();
 
     datum(tag::Part1{}) = 1;
     datum(tag::Part2{}) = 2;
@@ -232,8 +232,8 @@ TEST_CASE("VirtualDatum.operator=.propagation")
 
 TEST_CASE("VirtualDatum.operator=.multiview")
 {
-    auto datum1 = llama::stackVirtualDatumAlloc<Name>();
-    auto datum2 = llama::stackVirtualDatumAlloc<Name2>();
+    auto datum1 = llama::allocVirtualDatumStack<Name>();
+    auto datum2 = llama::allocVirtualDatumStack<Name2>();
 
     datum2 = 1;
     datum1 = datum2;
@@ -255,7 +255,7 @@ TEST_CASE("VirtualDatum.operator=.multiview")
 
 TEST_CASE("VirtualDatum.operator==")
 {
-    auto datum = llama::stackVirtualDatumAlloc<Name>();
+    auto datum = llama::allocVirtualDatumStack<Name>();
 
     datum = 1;
 
@@ -279,7 +279,7 @@ TEST_CASE("VirtualDatum.operator==")
 
 TEST_CASE("VirtualDatum.operator<")
 {
-    auto datum = llama::stackVirtualDatumAlloc<Name>();
+    auto datum = llama::allocVirtualDatumStack<Name>();
 
     datum = 1;
 

--- a/tests/virtualview.cpp
+++ b/tests/virtualview.cpp
@@ -54,18 +54,18 @@ TEST_CASE("fast virtual view")
 
     llama::VirtualView<decltype(view)> virtualView{
         view,
-        {23, 42}, // position
+        {23, 42}, // offset
         {13, 37} // size
     };
 
-    CHECK(virtualView.position == UserDomain{23, 42});
+    CHECK(virtualView.offset == UserDomain{23, 42});
     CHECK(virtualView.size == UserDomain{13, 37});
 
-    CHECK(view(virtualView.position)(tag::Pos(), tag::X()) == 966);
+    CHECK(view(virtualView.offset)(tag::Pos(), tag::X()) == 966);
     CHECK(virtualView({0, 0})(tag::Pos(), tag::X()) == 966);
 
     CHECK(
-        view({virtualView.position[0] + 2, virtualView.position[1] + 3})(
+        view({virtualView.offset[0] + 2, virtualView.offset[1] + 3})(
             tag::Vel(), tag::Z())
         == 1125);
     CHECK(virtualView({2, 3})(tag::Vel(), tag::Z()) == 1125);


### PR DESCRIPTION
* use operator() for allocators instead of member function allocate()
* rename Array::count to Array::rank
* rename all occurrences of the name UID to Tag.
* rename linearBytePosImpl to offsetOfImpl
* rename stackVirtualDatumAlloc() to allocVirtualDatumStack()
* rename stackVirtualDatumCopy() to copyVirtualDatumStack()
* move functors to implement VirtualDatum operators into internal namespace
* make several members private
* move macros generating VirtualDatum operators closer to where they are used and #undef them afterward
* remove obsolete access overloads in View and VirtualView
* replace license header by SPDX license identifier