### PR TITLE
Trace mapping for instrumentation

### DIFF
--- a/include/llama/Functions.hpp
+++ b/include/llama/Functions.hpp
@@ -366,4 +366,13 @@ namespace llama
     private:
         UserDomain<Dim> size;
     };
+
+    template<typename S>
+    auto structName(S) -> std::string
+    {
+        auto s = boost::core::demangle(typeid(S).name());
+        if(const auto pos = s.rfind(':'); pos != std::string::npos)
+            s = s.substr(pos + 1);
+        return s;
+    }
 }

--- a/include/llama/llama.hpp
+++ b/include/llama/llama.hpp
@@ -43,4 +43,5 @@
 #include "mapping/AoSoA.hpp"
 #include "mapping/One.hpp"
 #include "mapping/SoA.hpp"
+#include "mapping/Trace.hpp"
 #include "mapping/tree/Mapping.hpp"

--- a/include/llama/mapping/Dump.hpp
+++ b/include/llama/mapping/Dump.hpp
@@ -21,12 +21,9 @@ namespace llama::mapping
         }
 
         template<typename Tag>
-        auto tagToString(Tag)
+        auto tagToString(Tag tag)
         {
-            auto s = boost::core::demangle(typeid(Tag).name());
-            if(const auto pos = s.rfind(':'); pos != std::string::npos)
-                s = s.substr(pos + 1);
-            return s;
+            return structName(tag);
         }
 
         template<std::size_t N>

--- a/include/llama/mapping/Trace.hpp
+++ b/include/llama/mapping/Trace.hpp
@@ -3,7 +3,7 @@
 #include "../Types.hpp"
 #include "Common.hpp"
 
-#include <boost/atomic/atomic_ref.hpp>
+#include <atomic>
 #include <boost/core/demangle.hpp>
 #include <iostream>
 #include <string>
@@ -49,6 +49,9 @@ namespace llama::mapping
             });
         }
 
+        Trace(const Trace &) = delete;
+        auto operator=(const Trace &) -> Trace & = delete;
+
         Trace(Trace &&) noexcept = default;
         auto operator=(Trace &&) noexcept -> Trace & = default;
 
@@ -75,17 +78,14 @@ namespace llama::mapping
         {
             const static auto name = internal::coordName<DatumDomain>(
                 DatumCoord<DatumDomainCoord...>{});
-            boost::atomic_ref<std::size_t>
-            {
-                datumHits.at(name)
-            }
-            ++;
+            datumHits.at(name)++;
 
             LLAMA_FORCE_INLINE_RECURSIVE return mapping
                 .template getBlobNrAndOffset<DatumDomainCoord...>(coord);
         }
 
         Mapping mapping;
-        mutable std::unordered_map<std::string, std::size_t> datumHits;
+        mutable std::unordered_map<std::string, std::atomic<std::size_t>>
+            datumHits;
     };
 }

--- a/include/llama/mapping/Trace.hpp
+++ b/include/llama/mapping/Trace.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "../Types.hpp"
+#include "Common.hpp"
+
+#include <boost/atomic/atomic_ref.hpp>
+#include <boost/core/demangle.hpp>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace llama::mapping
+{
+    namespace internal
+    {
+        template<typename DatumDomain, std::size_t... Coords>
+        auto coordName(DatumCoord<Coords...>) -> std::string
+        {
+            using Tags = GetTags<DatumDomain, DatumCoord<Coords...>>;
+
+            std::string r;
+            boost::mp11::mp_for_each<Tags>([&](auto tag) {
+                if(!r.empty())
+                    r += '.';
+                r += structName(tag);
+            });
+            return r;
+        }
+    }
+
+    /// Forwards all calls to the inner mapping. Traces all accesses made
+    /// through this mapping and prints a summary on destruction.
+    /// \tparam Mapping The type of the inner mapping.
+    template<typename Mapping>
+    struct Trace
+    {
+        using UserDomain = typename Mapping::UserDomain;
+        using DatumDomain = typename Mapping::DatumDomain;
+        static constexpr std::size_t blobCount = Mapping::blobCount;
+
+        Trace() = default;
+
+        LLAMA_FN_HOST_ACC_INLINE
+        Trace(Mapping mapping) : mapping(mapping)
+        {
+            forEach<DatumDomain>([&](auto, auto inner) {
+                datumHits[internal::coordName<DatumDomain>(inner)] = 0;
+            });
+        }
+
+        Trace(Trace &&) noexcept = default;
+        auto operator=(Trace &&) noexcept -> Trace & = default;
+
+        ~Trace()
+        {
+            if(!datumHits.empty())
+            {
+                std::cout << "Trace mapping, number of accesses:\n";
+                for(const auto & [k, v] : datumHits)
+                    std::cout << '\t' << k << ":\t" << v << '\n';
+            }
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE auto getBlobSize(std::size_t i) const
+            -> std::size_t
+        {
+            LLAMA_FORCE_INLINE_RECURSIVE
+            return mapping.getBlobSize(i);
+        }
+
+        template<std::size_t... DatumDomainCoord>
+        LLAMA_FN_HOST_ACC_INLINE auto getBlobNrAndOffset(UserDomain coord) const
+            -> NrAndOffset
+        {
+            const static auto name = internal::coordName<DatumDomain>(
+                DatumCoord<DatumDomainCoord...>{});
+            boost::atomic_ref<std::size_t>
+            {
+                datumHits.at(name)
+            }
+            ++;
+
+            LLAMA_FORCE_INLINE_RECURSIVE return mapping
+                .template getBlobNrAndOffset<DatumDomainCoord...>(coord);
+        }
+
+        Mapping mapping;
+        mutable std::unordered_map<std::string, std::size_t> datumHits;
+    };
+}

--- a/tests/uid.cpp
+++ b/tests/uid.cpp
@@ -55,6 +55,16 @@ TEST_CASE("GetCoordFromTags")
     // clang-format on
 }
 
+TEST_CASE("GetTags")
+{
+    // clang-format off
+    STATIC_REQUIRE(std::is_same_v<llama::GetTags<Particle, llama::DatumCoord<0, 0>>, boost::mp11::mp_list<llama::NoName, tag::Pos, tag::X >>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetTags<Particle, llama::DatumCoord<0   >>, boost::mp11::mp_list<llama::NoName, tag::Pos         >>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetTags<Particle, llama::DatumCoord<    >>, boost::mp11::mp_list<llama::NoName                   >>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetTags<Particle, llama::DatumCoord<2, 1>>, boost::mp11::mp_list<llama::NoName, tag::Vel, tag::X >>);
+    // clang-format on
+}
+
 TEST_CASE("GetTag")
 {
     // clang-format off


### PR DESCRIPTION
Adds a Trace meta mapping that wraps another mapping and traces all accesses through it. A summary is print on destruction.